### PR TITLE
Features/troubleshooting action

### DIFF
--- a/k8s/deployment/kill_instances
+++ b/k8s/deployment/kill_instances
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "=== KILL INSTANCES ==="
+
+DEPLOYMENT_ID=$(echo "$CONTEXT" | jq -r '.parameters.deployment_id // .notification.parameters.deployment_id // empty')
+INSTANCE_NAME=$(echo "$CONTEXT" | jq -r '.parameters.instance_name // .notification.parameters.instance_name // empty')
+
+if [[ -z "$DEPLOYMENT_ID" ]] && [[ -n "${NP_ACTION_CONTEXT:-}" ]]; then
+    DEPLOYMENT_ID=$(echo "$NP_ACTION_CONTEXT" | jq -r '.notification.parameters.deployment_id // empty')
+fi
+
+if [[ -z "$INSTANCE_NAME" ]] && [[ -n "${NP_ACTION_CONTEXT:-}" ]]; then
+    INSTANCE_NAME=$(echo "$NP_ACTION_CONTEXT" | jq -r '.notification.parameters.instance_name // empty')
+fi
+
+if [[ -z "$DEPLOYMENT_ID" ]]; then
+    echo "ERROR: deployment_id parameter not found"
+    exit 1
+fi
+
+if [[ -z "$INSTANCE_NAME" ]]; then
+    echo "ERROR: instance_name parameter not found"
+    exit 1
+fi
+
+echo "Deployment ID: $DEPLOYMENT_ID"
+echo "Instance name: $INSTANCE_NAME"
+
+SCOPE_ID=$(echo "$CONTEXT" | jq -r '.tags.scope_id // .scope.id // .notification.tags.scope_id // empty')
+
+if [[ -z "$SCOPE_ID" ]] && [[ -n "${NP_ACTION_CONTEXT:-}" ]]; then
+    SCOPE_ID=$(echo "$NP_ACTION_CONTEXT" | jq -r '.notification.tags.scope_id // empty')
+fi
+
+K8S_NAMESPACE=$(echo "$CONTEXT" | jq -r --arg default "$K8S_NAMESPACE" '
+  .providers["container-orchestration"].cluster.namespace // $default
+' 2>/dev/null || echo "nullplatform")
+
+if [[ -z "$SCOPE_ID" ]]; then
+    echo "ERROR: scope_id not found in context"
+    exit 1
+fi
+
+echo "Scope ID: $SCOPE_ID"
+echo "Namespace: $K8S_NAMESPACE"
+
+if ! kubectl get pod "$INSTANCE_NAME" -n "$K8S_NAMESPACE" >/dev/null 2>&1; then
+    echo "ERROR: Pod $INSTANCE_NAME not found in namespace $K8S_NAMESPACE"
+    exit 1
+fi
+
+echo ""
+echo "=== POD DETAILS ==="
+POD_STATUS=$(kubectl get pod "$INSTANCE_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.status.phase}')
+POD_NODE=$(kubectl get pod "$INSTANCE_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.nodeName}')
+POD_START_TIME=$(kubectl get pod "$INSTANCE_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.status.startTime}')
+
+echo "Pod: $INSTANCE_NAME"
+echo "Status: $POD_STATUS"
+echo "Node: $POD_NODE"
+echo "Start time: $POD_START_TIME"
+
+DEPLOYMENT_NAME="d-$SCOPE_ID-$DEPLOYMENT_ID"
+echo "Expected deployment: $DEPLOYMENT_NAME"
+
+POD_DEPLOYMENT=$(kubectl get pod "$INSTANCE_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.ownerReferences[0].name}' 2>/dev/null || echo "")
+if [[ -n "$POD_DEPLOYMENT" ]]; then
+    REPLICASET_DEPLOYMENT=$(kubectl get replicaset "$POD_DEPLOYMENT" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.ownerReferences[0].name}' 2>/dev/null || echo "")
+    echo "Pod belongs to ReplicaSet: $POD_DEPLOYMENT"
+    echo "ReplicaSet belongs to Deployment: $REPLICASET_DEPLOYMENT"
+    
+    if [[ "$REPLICASET_DEPLOYMENT" != "$DEPLOYMENT_NAME" ]]; then
+        echo "WARNING: Pod does not belong to expected deployment $DEPLOYMENT_NAME"
+        echo "Continuing anyway..."
+    fi
+else
+    echo "WARNING: Could not verify pod ownership"
+fi
+
+echo ""
+echo "=== KILLING POD ==="
+
+kubectl delete pod "$INSTANCE_NAME" -n "$K8S_NAMESPACE" --grace-period=30
+
+echo "Pod deletion initiated with 30 second grace period"
+
+echo "Waiting for pod to be terminated..."
+kubectl wait --for=delete pod/"$INSTANCE_NAME" -n "$K8S_NAMESPACE" --timeout=60s || echo "Pod deletion timeout reached"
+
+if kubectl get pod "$INSTANCE_NAME" -n "$K8S_NAMESPACE" >/dev/null 2>&1; then
+    echo "WARNING: Pod still exists after deletion attempt"
+    POD_STATUS_AFTER=$(kubectl get pod "$INSTANCE_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.status.phase}')
+    echo "Current pod status: $POD_STATUS_AFTER"
+else
+    echo "Pod successfully terminated and removed"
+fi
+
+echo ""
+echo "=== DEPLOYMENT STATUS AFTER POD DELETION ==="
+if kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" >/dev/null 2>&1; then
+    DESIRED_REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.replicas}')
+    READY_REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.status.readyReplicas}')
+    AVAILABLE_REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.status.availableReplicas}')
+    
+    echo "Deployment: $DEPLOYMENT_NAME"
+    echo "Desired replicas: $DESIRED_REPLICAS"
+    echo "Ready replicas: ${READY_REPLICAS:-0}"
+    echo "Available replicas: ${AVAILABLE_REPLICAS:-0}"
+    
+    # If this is a managed deployment (with HPA or desired replicas > 0), 
+    # Kubernetes will automatically create a new pod to replace the killed one
+    if [[ "$DESIRED_REPLICAS" -gt 0 ]]; then
+        echo ""
+        echo "Note: Kubernetes will automatically create a new pod to replace the terminated one"
+        echo "This is expected behavior for managed deployments"
+    fi
+else
+    echo "WARNING: Deployment $DEPLOYMENT_NAME not found"
+fi
+
+echo ""
+echo "Instance $INSTANCE_NAME kill operation completed"

--- a/k8s/deployment/workflows/kill_instances.yaml
+++ b/k8s/deployment/workflows/kill_instances.yaml
@@ -1,0 +1,6 @@
+include:
+  - "$SERVICE_PATH/values.yaml"
+steps:
+  - name: kill instances
+    type: script
+    file: "$SERVICE_PATH/deployment/kill_instances"

--- a/k8s/scope/pause_autoscaling
+++ b/k8s/scope/pause_autoscaling
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEPLOYMENT_ID=$(echo "$CONTEXT" | jq .scope.current_active_deployment -r)
+SCOPE_ID=$(echo "$CONTEXT" | jq .scope.id -r)
+
+K8S_NAMESPACE=$(echo "$CONTEXT" | jq -r --arg default "$K8S_NAMESPACE" '
+  .providers["container-orchestration"].cluster.namespace // $default
+')
+
+HPA_NAME="hpa-d-$SCOPE_ID-$DEPLOYMENT_ID"
+
+if ! kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" >/dev/null 2>&1; then
+    echo "HPA $HPA_NAME not found in namespace $K8S_NAMESPACE"
+    exit 1
+fi
+
+CURRENT_CONFIG=$(kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" -o json)
+CURRENT_MIN=$(echo "$CURRENT_CONFIG" | jq -r '.spec.minReplicas')
+CURRENT_MAX=$(echo "$CURRENT_CONFIG" | jq -r '.spec.maxReplicas')
+
+echo "Current HPA configuration:"
+echo "  Min replicas: $CURRENT_MIN"
+echo "  Max replicas: $CURRENT_MAX"
+
+DEPLOYMENT_NAME="d-$SCOPE_ID-$DEPLOYMENT_ID"
+CURRENT_REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.replicas}')
+
+echo "Current deployment replicas: $CURRENT_REPLICAS"
+echo "Pausing autoscaling at $CURRENT_REPLICAS replicas..."
+
+PATCH=$(jq -n \
+  --arg originalMin "$CURRENT_MIN" \
+  --arg originalMax "$CURRENT_MAX" \
+  --arg pausedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --argjson currentReplicas "$CURRENT_REPLICAS" \
+  '{
+    metadata: {
+      annotations: {
+        "nullplatform.com/autoscaling-paused": (
+          {
+            originalMinReplicas: ($originalMin | tonumber),
+            originalMaxReplicas: ($originalMax | tonumber),
+            pausedAt: $pausedAt
+          } | tostring
+        )
+      }
+    },
+    spec: {
+      minReplicas: $currentReplicas,
+      maxReplicas: $currentReplicas
+    }
+  }')
+
+kubectl patch hpa "$HPA_NAME" -n "$K8S_NAMESPACE" --type='merge' -p "$PATCH"
+
+echo "Autoscaling paused successfully"
+echo "  HPA: $HPA_NAME"
+echo "  Namespace: $K8S_NAMESPACE"
+echo "  Fixed replicas: $CURRENT_REPLICAS"
+echo ""
+echo "To resume autoscaling, use the resume-autoscaling action or manually patch the HPA."

--- a/k8s/scope/resume_autoscaling
+++ b/k8s/scope/resume_autoscaling
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEPLOYMENT_ID=$(echo "$CONTEXT" | jq .scope.current_active_deployment -r)
+SCOPE_ID=$(echo "$CONTEXT" | jq .scope.id -r)
+
+K8S_NAMESPACE=$(echo "$CONTEXT" | jq -r --arg default "$K8S_NAMESPACE" '
+  .providers["container-orchestration"].cluster.namespace // $default
+')
+
+HPA_NAME="hpa-d-$SCOPE_ID-$DEPLOYMENT_ID"
+
+if ! kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" >/dev/null 2>&1; then
+    echo "HPA $HPA_NAME not found in namespace $K8S_NAMESPACE"
+    exit 1
+fi
+
+ANNOTATION_DATA=$(kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.annotations.nullplatform\.com/autoscaling-paused}' 2>/dev/null || echo "")
+
+if [[ -z "$ANNOTATION_DATA" || "$ANNOTATION_DATA" == "null" ]]; then
+    echo "HPA $HPA_NAME is not currently paused"
+    exit 1
+fi
+
+ORIGINAL_MIN=$(echo "$ANNOTATION_DATA" | jq -r '.originalMinReplicas')
+ORIGINAL_MAX=$(echo "$ANNOTATION_DATA" | jq -r '.originalMaxReplicas')
+
+PAUSED_AT=$(echo "$ANNOTATION_DATA" | jq -r '.pausedAt')
+
+echo "Found paused HPA configuration:"
+echo "  Original min replicas: $ORIGINAL_MIN"
+echo "  Original max replicas: $ORIGINAL_MAX"
+echo "  Paused at: $PAUSED_AT"
+
+echo "Resuming autoscaling..."
+
+PATCH=$(jq -n \
+  --argjson originalMin "$ORIGINAL_MIN" \
+  --argjson originalMax "$ORIGINAL_MAX" \
+  '{
+    metadata: {
+      annotations: {
+        "nullplatform.com/autoscaling-paused": null
+      }
+    },
+    spec: {
+      minReplicas: $originalMin,
+      maxReplicas: $originalMax
+    }
+  }')
+
+kubectl patch hpa "$HPA_NAME" -n "$K8S_NAMESPACE" --type='merge' -p "$PATCH"
+
+echo "Autoscaling resumed successfully"
+echo "  HPA: $HPA_NAME"
+echo "  Namespace: $K8S_NAMESPACE"
+echo "  Min replicas: $ORIGINAL_MIN"
+echo "  Max replicas: $ORIGINAL_MAX"

--- a/k8s/scope/set_desired_instance_count
+++ b/k8s/scope/set_desired_instance_count
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "=== SET DESIRED INSTANCE COUNT ==="
+
+DESIRED_INSTANCES="${ACTION_PARAMETERS_DESIRED_INSTANCES:-}"
+
+if [[ -z "$DESIRED_INSTANCES" ]]; then
+    echo "ERROR: desired_instances parameter not found"
+    echo "Expected ACTION_PARAMETERS_DESIRED_INSTANCES environment variable"
+    exit 1
+fi
+
+echo "Desired instances: $DESIRED_INSTANCES"
+
+DEPLOYMENT_ID=$(echo "$CONTEXT" | jq .scope.current_active_deployment -r)
+
+SCOPE_ID=$(echo "$CONTEXT" | jq .scope.id -r)
+
+K8S_NAMESPACE=$(echo "$CONTEXT" | jq -r --arg default "$K8S_NAMESPACE" '
+  .providers["container-orchestration"].cluster.namespace // $default
+')
+
+DEPLOYMENT_NAME="d-$SCOPE_ID-$DEPLOYMENT_ID"
+
+HPA_NAME="hpa-d-$SCOPE_ID-$DEPLOYMENT_ID"
+
+echo "Deployment: $DEPLOYMENT_NAME"
+echo "Namespace: $K8S_NAMESPACE"
+
+if ! kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" >/dev/null 2>&1; then
+    echo "ERROR: Deployment $DEPLOYMENT_NAME not found in namespace $K8S_NAMESPACE"
+    exit 1
+fi
+
+CURRENT_REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.replicas}')
+echo "Current replicas: $CURRENT_REPLICAS"
+
+HPA_EXISTS=false
+HPA_PAUSED=false
+if kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" >/dev/null 2>&1; then
+    HPA_EXISTS=true
+    echo "HPA found: $HPA_NAME"
+    
+    PAUSED_ANNOTATION=$(kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.annotations.nullplatform\.com/autoscaling-paused}' 2>/dev/null || echo "")
+    if [[ -n "$PAUSED_ANNOTATION" && "$PAUSED_ANNOTATION" != "null" ]]; then
+        HPA_PAUSED=true
+        echo "HPA is currently PAUSED"
+    else
+        echo "HPA is currently ACTIVE"
+    fi
+else
+    echo "No HPA found for this deployment"
+fi
+
+echo ""
+
+if [[ "$HPA_EXISTS" == "true" && "$HPA_PAUSED" == "false" ]]; then
+    echo "=== UPDATING HPA FOR ACTIVE AUTOSCALING ==="
+    
+    HPA_MIN=$(kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.minReplicas}')
+    HPA_MAX=$(kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.maxReplicas}')
+    
+    echo "Current HPA range: $HPA_MIN - $HPA_MAX replicas"
+    echo "Setting desired instances to $DESIRED_INSTANCES by updating HPA range"
+    
+    # Strategy: Set both min and max to desired count to force that exact replica count
+    # This effectively "pins" the deployment to the desired instance count
+    PATCH=$(jq -n \
+        --argjson desired "$DESIRED_INSTANCES" \
+        '{
+          spec: {
+            minReplicas: $desired,
+            maxReplicas: $desired
+          }
+        }')
+    
+    kubectl patch hpa "$HPA_NAME" -n "$K8S_NAMESPACE" --type='merge' -p "$PATCH"
+    echo "HPA updated: min=$DESIRED_INSTANCES, max=$DESIRED_INSTANCES"
+    
+elif [[ "$HPA_EXISTS" == "true" && "$HPA_PAUSED" == "true" ]]; then
+    # HPA is paused - just update deployment replicas
+    echo "=== UPDATING DEPLOYMENT (HPA PAUSED) ==="
+    
+    kubectl scale deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" --replicas="$DESIRED_INSTANCES"
+    echo "Deployment scaled to $DESIRED_INSTANCES replicas"
+    
+else
+    # No HPA or fixed scaling - just update deployment replicas
+    echo "=== UPDATING DEPLOYMENT (NO HPA) ==="
+    
+    kubectl scale deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" --replicas="$DESIRED_INSTANCES"
+    echo "Deployment scaled to $DESIRED_INSTANCES replicas"
+fi
+
+echo ""
+echo "Waiting for deployment rollout to complete..."
+kubectl rollout status deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" --timeout=300s
+
+echo ""
+echo "=== FINAL STATUS ==="
+FINAL_REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.replicas}')
+READY_REPLICAS=$(kubectl get deployment "$DEPLOYMENT_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.status.readyReplicas}')
+
+echo "Deployment replicas: $FINAL_REPLICAS"
+echo "Ready replicas: ${READY_REPLICAS:-0}"
+
+if [[ "$HPA_EXISTS" == "true" ]]; then
+    HPA_MIN=$(kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.minReplicas}')
+    HPA_MAX=$(kubectl get hpa "$HPA_NAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.maxReplicas}')
+    echo "HPA range: $HPA_MIN - $HPA_MAX replicas"
+fi
+
+echo ""
+echo "Instance count successfully set to $DESIRED_INSTANCES"

--- a/k8s/scope/workflows/pause-autoscaling.yaml
+++ b/k8s/scope/workflows/pause-autoscaling.yaml
@@ -1,0 +1,6 @@
+include:
+  - "$SERVICE_PATH/values.yaml"
+steps:
+  - name: pause autoscaling
+    type: script
+    file: "$SERVICE_PATH/scope/pause_autoscaling"

--- a/k8s/scope/workflows/resume-autoscaling.yaml
+++ b/k8s/scope/workflows/resume-autoscaling.yaml
@@ -1,0 +1,6 @@
+include:
+  - "$SERVICE_PATH/values.yaml"
+steps:
+  - name: resume autoscaling
+    type: script
+    file: "$SERVICE_PATH/scope/resume_autoscaling"

--- a/k8s/scope/workflows/set-desired-instance-count.yaml
+++ b/k8s/scope/workflows/set-desired-instance-count.yaml
@@ -1,0 +1,6 @@
+include:
+  - "$SERVICE_PATH/values.yaml"
+steps:
+  - name: set desired instance count
+    type: script
+    file: "$SERVICE_PATH/scope/set_desired_instance_count"

--- a/k8s/specs/actions/kill-instances.json.tpl
+++ b/k8s/specs/actions/kill-instances.json.tpl
@@ -1,0 +1,18 @@
+{
+  "name": "Kill instances",
+  "type": "custom",
+  "icon": "material-symbols:delete-outline",
+  "results": {
+    "schema": { "type": "object", "required": [], "properties": {} },
+    "values": {}
+  },
+  "service_specification_id": "{{ env.Getenv "SERVICE_SPECIFICATION_ID" }}",
+  "parameters": {
+    "schema": { "type": "object", "required": [], "properties": {} },
+    "values": {}
+  },
+  "annotations": {
+    "show_on": ["performance"],
+    "runs_over": "deployment"
+  }
+}

--- a/k8s/specs/actions/pause-autoscaling.json.tpl
+++ b/k8s/specs/actions/pause-autoscaling.json.tpl
@@ -1,0 +1,18 @@
+{
+  "name": "Pause autoscaling",
+  "type": "custom",
+  "icon": "material-symbols:pause-circle-outline",
+  "results": {
+    "schema": { "type": "object", "required": [], "properties": {} },
+    "values": {}
+  },
+  "service_specification_id": "{{ env.Getenv "SERVICE_SPECIFICATION_ID" }}",
+  "parameters": {
+    "schema": { "type": "object", "required": [], "properties": {} },
+    "values": {}
+  },
+  "annotations": {
+    "show_on": ["performance"],
+    "runs_over": "scope"
+  }
+}

--- a/k8s/specs/actions/pause-autoscaling.json.tpl
+++ b/k8s/specs/actions/pause-autoscaling.json.tpl
@@ -14,5 +14,6 @@
   "annotations": {
     "show_on": ["performance"],
     "runs_over": "scope"
-  }
+  },
+  "enabled_when": ".service.attributes.scaling_type == \"auto\""
 }

--- a/k8s/specs/actions/resume-autoscaling.json.tpl
+++ b/k8s/specs/actions/resume-autoscaling.json.tpl
@@ -14,5 +14,6 @@
   "annotations": {
     "show_on": ["performance"],
     "runs_over": "scope"
-  }
+  },
+  "enabled_when": ".service.attributes.scaling_type == \"auto\""
 }

--- a/k8s/specs/actions/resume-autoscaling.json.tpl
+++ b/k8s/specs/actions/resume-autoscaling.json.tpl
@@ -1,0 +1,18 @@
+{
+  "name": "Resume autoscaling",
+  "type": "custom",
+  "icon": "material-symbols:play-circle-outline",
+  "results": {
+    "schema": { "type": "object", "required": [], "properties": {} },
+    "values": {}
+  },
+  "service_specification_id": "{{ env.Getenv "SERVICE_SPECIFICATION_ID" }}",
+  "parameters": {
+    "schema": { "type": "object", "required": [], "properties": {} },
+    "values": {}
+  },
+  "annotations": {
+    "show_on": ["performance"],
+    "runs_over": "scope"
+  }
+}

--- a/k8s/specs/actions/set-desired-instance-count.json.tpl
+++ b/k8s/specs/actions/set-desired-instance-count.json.tpl
@@ -1,0 +1,33 @@
+{
+  "name": "Set desired instance count",
+  "type": "custom",
+  "icon": "material-symbols:note-add-outline",
+  "results": {
+    "schema": { "type": "object", "required": [], "properties": {} },
+    "values": {}
+  },
+  "service_specification_id": "{{ env.Getenv "SERVICE_SPECIFICATION_ID" }}",
+  "parameters": {
+    "schema": {
+      "type": "object",
+      "required": ["desired_instances"],
+      "properties": {
+        "desired_instances": {
+          "type": "integer",
+          "title": "Desired Instance Count",
+          "description": "Set the number of instances you want to run",
+          "additionalKeywords": {
+            "default": ".service.attributes.autoscaling.min_replicas // 1",
+            "maximum": ".service.attributes.autoscaling.max_replicas // 10",
+            "minimum": ".service.attributes.autoscaling.min_replicas // 1"
+          }
+        }
+      }
+    },
+    "values": {}
+  },
+  "annotations": {
+    "show_on": ["performance"],
+    "runs_over": "scope"
+  }
+}

--- a/service/deployment/entrypoint
+++ b/service/deployment/entrypoint
@@ -23,6 +23,9 @@ case "$SERVICE_ACTION" in
   "delete-deployment")
     ACTION_TO_EXECUTE="delete"
     ;;
+  "kill-instances")
+    ACTION_TO_EXECUTE="kill_instances"
+    ;;
   *)
     echo "Unknown action: $SERVICE_ACTION"
     exit 1


### PR DESCRIPTION
# Add Autoscaling Control and Instance Management Actions

This PR adds a set of troubleshooting actions for Kubernetes deployments, giving operators better control over autoscaling and instance management.

## What's New

**Autoscaling Actions:**
- **Pause Autoscaling** - Temporarily freeze scaling at current replica count
- **Resume Autoscaling** - Restore original HPA settings  
- **Set Desired Instance Count** - Adjust replica count with smart scaling logic

**Instance Management:**
- **Kill Instances** - Safely terminate specific pods

## How It Works

- **Pause/Resume**: Stores original HPA config in annotations, sets min=max=current to freeze scaling
- **Set Instance Count**: Updates HPA range for active scaling, or directly scales deployment when paused/disabled
- **Kill Instances**: Graceful pod termination with 30s grace period, Kubernetes auto-replaces

## UI Integration

Actions appear in a troubleshooting modal with dynamic forms. Autoscaling actions only show when `scaling_type == "auto"`.

**Screenshots:**
- [Troubleshooting modal with all actions](https://github.com/user-attachments/assets/1a99a741-bee0-4e73-a2f3-1a29643069fa)
- [Set desired instances with dynamic config](https://github.com/user-attachments/assets/d61558a8-695c-44be-8f62-cd0695b7ccd1)  
- [Kill instances interface](https://github.com/user-attachments/assets/993a5fe9-33bf-4ad5-b06f-6671115283d3)

## Use Cases

- Load testing with specific replica counts
- Pause autoscaling during incident response
- Kill problematic pods for quick recovery
- Override autoscaling for maintenance windows