### PR TITLE
[fix] improve error handling in deployment scripts

### DIFF
--- a/k8s/deployment/wait_deployment_active
+++ b/k8s/deployment/wait_deployment_active
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-echo $SCOPE_ID
-echo $DEPLOYMENT_ID
+set -euo pipefail
+
+echo "Waiting for deployment to become active"
+echo "Scope ID: $SCOPE_ID"
+echo "Deployment ID: $DEPLOYMENT_ID"
 
 MAX_ITERATIONS=$(( TIMEOUT / 10 ))
 K8S_DEPLOYMENT_NAME="d-$SCOPE_ID-$DEPLOYMENT_ID"
@@ -12,12 +15,19 @@ SKIP_DEPLOYMENT_STATUS_CHECK="${SKIP_DEPLOYMENT_STATUS_CHECK:=false}"
 while true; do
     ((iteration++))
     if [ $iteration -gt $MAX_ITERATIONS ]; then
-        echo "Error: Maximum number of iterations (${MAX_ITERATIONS}) reached. Not all pods are available."
+        echo "ERROR: Timeout waiting for deployment. Maximum iterations (${MAX_ITERATIONS}) reached."
         exit 1
     fi
-    D_STATUS=$(np deployment read --id $DEPLOYMENT_ID --api-key $NP_API_KEY --query .status)
-    if [[ -n $CHECK_DEPLOYMENT_STATUS ]]; then
-        echo "Error: Deployment status not found"
+    
+    echo "Checking deployment status (attempt $iteration/$MAX_ITERATIONS)..."
+    D_STATUS=$(np deployment read --id $DEPLOYMENT_ID --api-key $NP_API_KEY --query .status 2>&1) || {
+        echo "ERROR: Failed to read deployment status"
+        echo "NP CLI error: $D_STATUS"
+        exit 1
+    }
+    
+    if [[ -z "$D_STATUS" ]] || [[ "$D_STATUS" == "null" ]]; then
+        echo "ERROR: Deployment status not found for ID $DEPLOYMENT_ID"
         exit 1
     fi
 

--- a/k8s/scope/iam/build_service_account
+++ b/k8s/scope/iam/build_service_account
@@ -1,16 +1,33 @@
 #!/bin/bash
 
+set -euo pipefail
+
 IAM=${IAM-"{}"}
 
 IAM_ENABLED=$(echo "$IAM" | jq -r .ENABLED)
 
 if [[ "$IAM_ENABLED" == "false" || "$IAM_ENABLED" == "null" ]]; then
+  echo "IAM is not enabled, skipping service account setup"
   return
 fi
 
-AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+echo "Getting AWS account ID..."
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>&1) || {
+  echo "ERROR: Failed to get AWS account ID"
+  echo "AWS Error: $AWS_ACCOUNT_ID"
+  echo "Check if AWS credentials are configured correctly"
+  exit 1
+}
+
 SERVICE_ACCOUNT_NAME=$(echo "$IAM" | jq -r .PREFIX)-"$SCOPE_ID"
-ROLE_ARN=$(aws iam get-role --role-name "$SERVICE_ACCOUNT_NAME" --query 'Role.Arn' --output text)
+echo "Looking for IAM role: $SERVICE_ACCOUNT_NAME"
+
+ROLE_ARN=$(aws iam get-role --role-name "$SERVICE_ACCOUNT_NAME" --query 'Role.Arn' --output text 2>&1) || {
+  echo "ERROR: Failed to find IAM role '$SERVICE_ACCOUNT_NAME'"
+  echo "AWS Error: $ROLE_ARN"
+  echo "Make sure the role exists and you have IAM permissions"
+  exit 1
+}
 
 CONTEXT_PATH="$OUTPUT_DIR/context-$SCOPE_ID.json"
 SERVICE_ACCOUNT_PATH="$OUTPUT_DIR/service_account-$SCOPE_ID.yaml"

--- a/k8s/scope/iam/create_role
+++ b/k8s/scope/iam/create_role
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+echo "Creating IAM role for service account: $ROLE_NAME"
+
 IAM=${IAM-"{}"}
 
 IAM_ENABLED=$(echo "$IAM" | jq -r .ENABLED)
@@ -14,8 +16,19 @@ fi
 ROLE_NAME=$(echo "$IAM" | jq -r .PREFIX)-"$SCOPE_ID"
 ROLE_PATH="/nullplatform/custom-scopes/"
 NAMESPACE=$(echo "$CONTEXT" | jq -r .k8s_namespace)
-OIDC_PROVIDER=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
-AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+echo "Getting EKS OIDC provider for cluster: $CLUSTER_NAME"
+OIDC_PROVIDER=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query "cluster.identity.oidc.issuer" --output text 2>&1 | sed -e "s/^https:\/\///") || {
+  echo "ERROR: Failed to get OIDC provider for EKS cluster '$CLUSTER_NAME'"
+  echo "AWS Error: $OIDC_PROVIDER"
+  exit 1
+}
+
+echo "Getting AWS account ID"
+AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>&1) || {
+  echo "ERROR: Failed to get AWS account ID"
+  echo "AWS Error: $AWS_ACCOUNT_ID"
+  exit 1
+}
 TRUST_POLICY_PATH="$OUTPUT_DIR/trust-policy.json"
 
 # Step 1: Create the IAM trust policy

--- a/k8s/scope/networking/dns/az-records/manage_route
+++ b/k8s/scope/networking/dns/az-records/manage_route
@@ -1,15 +1,30 @@
 #!/bin/bash
 
+set -euo pipefail
+
 get_azure_token() {
+    echo "Getting Azure access token..."
     local token_response=$(curl -s -X POST \
         "https://login.microsoftonline.com/${AZURE_TENANT_ID}/oauth2/v2.0/token" \
         -H "Content-Type: application/x-www-form-urlencoded" \
         -d "client_id=${AZURE_CLIENT_ID}" \
         -d "client_secret=${AZURE_CLIENT_SECRET}" \
         -d "scope=https://management.azure.com/.default" \
-        -d "grant_type=client_credentials")
-
-    echo "$token_response" | grep -o '"access_token":"[^"]*' | cut -d'"' -f4
+        -d "grant_type=client_credentials" 2>&1) || {
+        echo "ERROR: Failed to get Azure access token"
+        echo "Curl error: $token_response"
+        return 1
+    }
+    
+    local access_token=$(echo "$token_response" | grep -o '"access_token":"[^"]*' | cut -d'"' -f4)
+    
+    if [[ -z "$access_token" ]]; then
+        echo "ERROR: No access token in response"
+        echo "Response: $token_response"
+        return 1
+    fi
+    
+    echo "$access_token"
 }
 
 ACTION=""
@@ -74,11 +89,24 @@ if [ "$ACTION" = "CREATE" ]; then
 EOF
 )
     
-    curl -s -X PUT \
+    echo "Creating Azure DNS record: ${SCOPE_SUBDOMAIN} -> ${GATEWAY_IP}"
+    
+    AZURE_RESPONSE=$(curl -s -X PUT \
         "${RECORD_SET_URL}" \
         -H "Authorization: Bearer ${ACCESS_TOKEN}" \
         -H "Content-Type: application/json" \
-        -d "${RECORD_BODY}"
+        -d "${RECORD_BODY}" 2>&1) || {
+        echo "ERROR: Failed to create/update Azure DNS record"
+        echo "Curl error: $AZURE_RESPONSE"
+        exit 1
+    }
+    
+    # Check if response contains error
+    if echo "$AZURE_RESPONSE" | grep -q '"error"'; then
+        echo "ERROR: Azure API returned error"
+        echo "Response: $AZURE_RESPONSE"
+        exit 1
+    fi
     
     echo "Record created/updated successfully"
     

--- a/k8s/scope/networking/dns/manage_dns
+++ b/k8s/scope/networking/dns/manage_dns
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+set -euo pipefail
+
+echo "Managing DNS records"
+echo "DNS Type: $DNS_TYPE"
+echo "Action: $ACTION"
+
 case "$DNS_TYPE" in
   route53)
-    source "$SERVICE_PATH/scope/networking/dns/route53/manage_route" --action="$ACTION"
+    echo "Using Route53 DNS provider"
+    source "$SERVICE_PATH/scope/networking/dns/route53/manage_route" --action="$ACTION" || {
+        echo "ERROR: Route53 DNS management failed"
+        exit 1
+    }
     ;;
   azure)
     if [ "$SCOPE_VISIBILITY" = "public" ]; then

--- a/k8s/scope/networking/dns/route53/manage_route
+++ b/k8s/scope/networking/dns/route53/manage_route
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 ACTION=""
 
 for arg in "$@"; do
@@ -8,12 +10,28 @@ for arg in "$@"; do
   esac
 done
 
-read -r ELB_DNS_NAME ELB_HOSTED_ZONE_ID <<< $(aws elbv2 describe-load-balancers \
+echo "Looking for load balancer: $ALB_NAME in region $REGION"
+
+# Get load balancer info and check if it exists
+LB_OUTPUT=$(aws elbv2 describe-load-balancers \
     --names "$ALB_NAME" \
     --region "$REGION" \
     --query 'LoadBalancers[0].[DNSName,CanonicalHostedZoneId]' \
     --output text \
-    --no-paginate)
+    --no-paginate 2>&1) || {
+    echo "ERROR: Failed to find load balancer '$ALB_NAME' in region '$REGION'"
+    echo "AWS Error: $LB_OUTPUT"
+    exit 1
+}
+
+read -r ELB_DNS_NAME ELB_HOSTED_ZONE_ID <<< "$LB_OUTPUT"
+
+if [[ -z "$ELB_DNS_NAME" ]] || [[ "$ELB_DNS_NAME" == "None" ]]; then
+    echo "ERROR: Load balancer '$ALB_NAME' exists but has no DNS name"
+    exit 1
+fi
+
+echo "Found load balancer DNS: $ELB_DNS_NAME"
 
 if [ "$SCOPE_VISIBILITY" = "public" ]; then
     HOSTED_ZONES=("$HOSTED_PUBLIC_ZONE_ID")
@@ -23,8 +41,9 @@ fi
 
 for ZONE_ID in "${HOSTED_ZONES[@]}"; do
     echo "Creating Route53 record in hosted zone: $ZONE_ID"
+    echo "Domain: $SCOPE_DOMAIN -> $ELB_DNS_NAME"
 
-    aws route53 change-resource-record-sets \
+    ROUTE53_OUTPUT=$(aws route53 change-resource-record-sets \
         --hosted-zone-id "$ZONE_ID" \
         --region "$REGION" \
         --no-paginate \
@@ -43,5 +62,13 @@ for ZONE_ID in "${HOSTED_ZONES[@]}"; do
                     }
                 }
             ]
-        }"
+        }" 2>&1) || {
+        echo "ERROR: Failed to create Route53 record"
+        echo "Zone ID: $ZONE_ID"
+        echo "AWS Error: $ROUTE53_OUTPUT"
+        echo "This often happens when the agent lacks Route53 permissions"
+        exit 1
+    }
+    
+    echo "Successfully created Route53 record"
 done

--- a/k8s/scope/restart_pods
+++ b/k8s/scope/restart_pods
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 DEPLOYMENT_ID=$(echo "$CONTEXT" | jq .scope.current_active_deployment -r)
 SCOPE_ID=$(echo "$CONTEXT" | jq .scope.id -r)
 
@@ -7,8 +9,29 @@ K8S_NAMESPACE=$(echo "$CONTEXT" | jq -r --arg default "$K8S_NAMESPACE" '
   .providers["container-orchestration"].cluster.namespace // $default
 ')
 
-DEPLOYMENT=$(kubectl get deployment -n "$K8S_NAMESPACE" -l "name=d-$SCOPE_ID-$DEPLOYMENT_ID" -o jsonpath="{.items[0].metadata.name}" 2>/dev/null )
+echo "Looking for deployment with label: name=d-$SCOPE_ID-$DEPLOYMENT_ID"
+DEPLOYMENT=$(kubectl get deployment -n "$K8S_NAMESPACE" -l "name=d-$SCOPE_ID-$DEPLOYMENT_ID" -o jsonpath="{.items[0].metadata.name}" 2>&1) || {
+    echo "ERROR: Failed to find deployment"
+    echo "Namespace: $K8S_NAMESPACE"
+    echo "Kubectl error: $DEPLOYMENT"
+    exit 1
+}
 
-kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$DEPLOYMENT"
+if [[ -z "$DEPLOYMENT" ]]; then
+    echo "ERROR: No deployment found with label name=d-$SCOPE_ID-$DEPLOYMENT_ID"
+    exit 1
+fi
 
-kubectl rollout status -n "$K8S_NAMESPACE" "deployment/$DEPLOYMENT" -w
+echo "Restarting deployment: $DEPLOYMENT"
+kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$DEPLOYMENT" || {
+    echo "ERROR: Failed to restart deployment $DEPLOYMENT"
+    exit 1
+}
+
+echo "Waiting for rollout to complete..."
+kubectl rollout status -n "$K8S_NAMESPACE" "deployment/$DEPLOYMENT" -w || {
+    echo "ERROR: Rollout failed or timed out"
+    exit 1
+}
+
+echo "Deployment restart completed successfully"


### PR DESCRIPTION
- Add set -euo pipefail to prevent silent failures
- Enhance AWS CLI error handling with meaningful error messages
- Fix Route53 DNS script to catch load balancer lookup failures
- Improve Azure DNS script with token validation and API error checking
- Add proper error checking to IAM role creation and service account scripts
- Fix deployment waiting script to properly validate NP CLI responses
- Enhance pod restart script to verify deployment exists before restart
- Add progress logging to help troubleshoot deployment issues