### PR TITLE
Safe scope delete

### DIFF
--- a/k8s/scope/iam/build_service_account
+++ b/k8s/scope/iam/build_service_account
@@ -23,6 +23,11 @@ SERVICE_ACCOUNT_NAME=$(echo "$IAM" | jq -r .PREFIX)-"$SCOPE_ID"
 echo "Looking for IAM role: $SERVICE_ACCOUNT_NAME"
 
 ROLE_ARN=$(aws iam get-role --role-name "$SERVICE_ACCOUNT_NAME" --query 'Role.Arn' --output text 2>&1) || {
+  if [[ "${ACTION:-}" == "delete" ]] && [[ "$ROLE_ARN" == *"NoSuchEntity"* ]] && [[ "$ROLE_ARN" == *"cannot be found"* ]]; then
+    echo "IAM role '$SERVICE_ACCOUNT_NAME' does not exist, skipping service account deletion"
+    return 0
+  fi
+
   echo "ERROR: Failed to find IAM role '$SERVICE_ACCOUNT_NAME'"
   echo "AWS Error: $ROLE_ARN"
   echo "Make sure the role exists and you have IAM permissions"

--- a/k8s/scope/iam/delete_role
+++ b/k8s/scope/iam/delete_role
@@ -11,6 +11,18 @@ if [[ "$IAM_ENABLED" == "false" || "$IAM_ENABLED" == "null" ]]; then
   return
 fi
 
+ROLE_ARN=$(aws iam get-role --role-name "$SERVICE_ACCOUNT_NAME" --query 'Role.Arn' --output text 2>&1) || {
+  if [[ "$ROLE_ARN" == *"NoSuchEntity"* ]] && [[ "$ROLE_ARN" == *"cannot be found"* ]]; then
+    echo "IAM role '$SERVICE_ACCOUNT_NAME' does not exist, skipping role deletion"
+    return 0
+  fi
+
+  echo "ERROR: Failed to find IAM role '$SERVICE_ACCOUNT_NAME'"
+  echo "AWS Error: $ROLE_ARN"
+  echo "Make sure the role exists and you have IAM permissions"
+  exit 1
+}
+
 ROLE_NAME=$(echo "$IAM" | jq -r .PREFIX)-"$SCOPE_ID"
 
 echo "Detaching managed policies..."

--- a/k8s/scope/networking/dns/manage_dns
+++ b/k8s/scope/networking/dns/manage_dns
@@ -5,6 +5,12 @@ set -euo pipefail
 echo "Managing DNS records"
 echo "DNS Type: $DNS_TYPE"
 echo "Action: $ACTION"
+echo "Scope Domain: $SCOPE_DOMAIN"
+
+if [[ "$ACTION" == "DELETE" ]] && [[ -z "${SCOPE_DOMAIN:-}" || "${SCOPE_DOMAIN:-}" == "To be defined" ]]; then
+    echo "Skipping route53 action as the scope has no domain"
+    return 0
+fi
 
 case "$DNS_TYPE" in
   route53)

--- a/k8s/scope/networking/dns/route53/manage_route
+++ b/k8s/scope/networking/dns/route53/manage_route
@@ -74,12 +74,12 @@ for ZONE_ID in "${HOSTED_ZONES[@]}"; do
                 }
             ]
         }" 2>&1) || {
-        echo "ERROR: Failed to create Route53 record"
+        echo "ERROR: Failed to $ACTION Route53 record"
         echo "Zone ID: $ZONE_ID"
         echo "AWS Error: $ROUTE53_OUTPUT"
         echo "This often happens when the agent lacks Route53 permissions"
         exit 1
     }
     
-    echo "Successfully created Route53 record"
+    echo "Successfully $ACTION Route53 record"
 done

--- a/k8s/scope/networking/dns/route53/manage_route
+++ b/k8s/scope/networking/dns/route53/manage_route
@@ -76,7 +76,7 @@ for ZONE_ID in "${HOSTED_ZONES[@]}"; do
         }" 2>&1) || {
 
             if [[ "$ACTION" == "DELETE" ]] && [[ "$ROUTE53_OUTPUT" == *"InvalidChangeBatch"* ]] && [[ "$ROUTE53_OUTPUT" == *"but it was not found"* ]]; then
-          echo "Route53 record for $SCOPE_DOMAIN was already deleted or never created in zone $ZONE_ID"
+          echo "Route53 record for $SCOPE_DOMAIN does not exist in zone $ZONE_ID, skipping deletion"
           continue
         fi
 

--- a/k8s/scope/networking/dns/route53/manage_route
+++ b/k8s/scope/networking/dns/route53/manage_route
@@ -74,6 +74,12 @@ for ZONE_ID in "${HOSTED_ZONES[@]}"; do
                 }
             ]
         }" 2>&1) || {
+
+            if [[ "$ACTION" == "DELETE" ]] && [[ "$ROUTE53_OUTPUT" == *"InvalidChangeBatch"* ]] && [[ "$ROUTE53_OUTPUT" == *"but it was not found"* ]]; then
+          echo "Route53 record for $SCOPE_DOMAIN was already deleted or never created in zone $ZONE_ID"
+          continue
+        fi
+
         echo "ERROR: Failed to $ACTION Route53 record"
         echo "Zone ID: $ZONE_ID"
         echo "AWS Error: $ROUTE53_OUTPUT"

--- a/k8s/scope/workflows/create.yaml
+++ b/k8s/scope/workflows/create.yaml
@@ -22,6 +22,8 @@ steps:
       - name: build service account
         type: script
         file: "$SERVICE_PATH/scope/iam/build_service_account"
+        configuration:
+          ACTION: create
         output:
           - name: SERVICE_ACCOUNT_TEMPLATE_PATH
             type: file

--- a/k8s/scope/workflows/delete.yaml
+++ b/k8s/scope/workflows/delete.yaml
@@ -36,6 +36,8 @@ steps:
       - name: build service account
         type: script
         file: "$SERVICE_PATH/scope/iam/build_service_account"
+        configuration:
+          ACTION: delete
         output:
           - name: SERVICE_ACCOUNT_TEMPLATE_PATH
             type: file

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -22,7 +22,7 @@ configuration:
   # VAULT_ADDR: "http://localhost:8200"
   # VAULT_TOKEN: "myroot"
   IAM:
-    ENABLED: false
+    ENABLED: true
 #    PREFIX: nullplatform-scopes
 #    ROLE:
 #      POLICIES:

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -22,7 +22,7 @@ configuration:
   # VAULT_ADDR: "http://localhost:8200"
   # VAULT_TOKEN: "myroot"
   IAM:
-    ENABLED: true
+    ENABLED: false
 #    PREFIX: nullplatform-scopes
 #    ROLE:
 #      POLICIES:


### PR DESCRIPTION
Estuvimos teniendo muchos reportes de casos de scopes que no se pueden borrar, esto suele ocurrir cuando un scope no se creó correctamente.

Al realizar el delete suele ocurrir que el DNS o el role de IAM no existen. Este PR agrega lógica para seguir adelante e ignorar errores borrando cosas cuando estas no existen