### PR TITLE
chore: migrate shellcheck to reusable workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,13 +12,7 @@ jobs:
       go-version: '1.25'
 
   shellcheck:
-    name: ShellCheck
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Run ShellCheck
-        run: find . -name "*.sh" -not -path "./.git/*" | xargs shellcheck --severity=error
+    uses: nullplatform/actions-nullplatform/.github/workflows/shellcheck.yml@main
 
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
## Summary

- Replace inline `shellcheck` job with the org reusable workflow
- Behavior is identical: `find *.sh` + `--severity=error` (the reusable default)

## Notes

- Depends on nullplatform/actions-nullplatform#45 being merged first