### PR TITLE
Skip ALB capacity validations in scheduled_task workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ testing/docker/certs/
 
 # Claude Code
 .claude/
+
+# Visual Studio Code
+.vscode/

--- a/scheduled_task/deployment/tests/workflow_overrides.bats
+++ b/scheduled_task/deployment/tests/workflow_overrides.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Tests that verify scheduled_task deployment workflows override base k8s steps
+# that do not apply to this scope type (e.g. ALB target group capacity).
+#
+# Contract:
+#   - Overlay must mark the step with `action: skip`.
+#   - Base workflow must still declare the step under the same name, otherwise
+#     a rename upstream would silently re-enable the step here.
+# =============================================================================
+
+setup() {
+  export PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  source "$PROJECT_ROOT/testing/assertions.sh"
+
+  export OVERLAY="$PROJECT_ROOT/scheduled_task/deployment/workflows/initial.yaml"
+  export BASE="$PROJECT_ROOT/k8s/deployment/workflows/initial.yaml"
+}
+
+# =============================================================================
+# validate alb target group capacity
+# =============================================================================
+@test "base k8s deployment initial workflow declares 'validate alb target group capacity' step" {
+  run grep -A 2 "name: validate alb target group capacity" "$BASE"
+
+  assert_equal "$status" "0"
+  assert_contains "$output" "type: script"
+  assert_contains "$output" "validate_alb_target_group_capacity"
+}
+
+@test "scheduled_task deployment initial overlay skips 'validate alb target group capacity'" {
+  run grep -A 1 "name: validate alb target group capacity" "$OVERLAY"
+
+  assert_equal "$status" "0"
+  assert_contains "$output" "action: skip"
+}

--- a/scheduled_task/deployment/workflows/initial.yaml
+++ b/scheduled_task/deployment/workflows/initial.yaml
@@ -1,6 +1,8 @@
 include:
   - "$SERVICE_PATH/values.yaml"
 steps:
+  - name: validate alb target group capacity
+    action: skip
   - name: route traffic
     action: skip
   - name: create deployment

--- a/scheduled_task/scope/tests/workflow_overrides.bats
+++ b/scheduled_task/scope/tests/workflow_overrides.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Tests that verify scheduled_task scope workflows override base k8s steps
+# that do not apply to this scope type (e.g. ALB capacity validation).
+#
+# Contract:
+#   - Overlay must mark the step with `action: skip`.
+#   - Base workflow must still declare the step under the same name, otherwise
+#     the skip is a no-op and the base step would not run anyway (or worse, a
+#     rename upstream would silently re-enable the step here).
+# =============================================================================
+
+setup() {
+  export PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  source "$PROJECT_ROOT/testing/assertions.sh"
+
+  export OVERLAY="$PROJECT_ROOT/scheduled_task/scope/workflows/create.yaml"
+  export BASE="$PROJECT_ROOT/k8s/scope/workflows/create.yaml"
+}
+
+# =============================================================================
+# validate alb capacity
+# =============================================================================
+@test "base k8s scope create workflow declares 'validate alb capacity' step" {
+  run grep -A 2 "name: validate alb capacity" "$BASE"
+
+  assert_equal "$status" "0"
+  assert_contains "$output" "type: script"
+  assert_contains "$output" "validate_alb_capacity"
+}
+
+@test "scheduled_task scope create overlay skips 'validate alb capacity'" {
+  run grep -A 1 "name: validate alb capacity" "$OVERLAY"
+
+  assert_equal "$status" "0"
+  assert_contains "$output" "action: skip"
+}
+
+# =============================================================================
+# networking (scheduled_task has no public traffic, so the whole block is skipped)
+# =============================================================================
+@test "base k8s scope create workflow declares 'networking' step" {
+  run grep -A 1 "name: networking" "$BASE"
+
+  assert_equal "$status" "0"
+  assert_contains "$output" "type: workflow"
+}
+
+@test "scheduled_task scope create overlay skips 'networking'" {
+  run grep -A 1 "name: networking" "$OVERLAY"
+
+  assert_equal "$status" "0"
+  assert_contains "$output" "action: skip"
+}

--- a/scheduled_task/scope/workflows/create.yaml
+++ b/scheduled_task/scope/workflows/create.yaml
@@ -3,3 +3,5 @@ include:
 steps:
   - name: networking
     action: skip
+  - name: validate alb capacity
+    action: skip


### PR DESCRIPTION
## Summary
- Skip `networking` and `validate alb capacity` in [scheduled_task/scope/workflows/create.yaml](scheduled_task/scope/workflows/create.yaml) — these scopes don't expose HTTP traffic via ALB.
- Skip `validate alb target group capacity` in [scheduled_task/deployment/workflows/initial.yaml](scheduled_task/deployment/workflows/initial.yaml) for the same reason.
- Add structural tests in [scheduled_task/scope/tests/workflow_overrides.bats](scheduled_task/scope/tests/workflow_overrides.bats) and [scheduled_task/deployment/tests/workflow_overrides.bats](scheduled_task/deployment/tests/workflow_overrides.bats) that lock the contract with base k8s workflows: each skipped step is verified on both sides (overlay has `action: skip`, base still declares the step under that name), so an upstream rename fails the test instead of silently orphaning the skip.
- Add `.vscode/` to `.gitignore`.
