### PR TITLE
feat(istio): add external-dns visibility annotation to HTTPRoute templates

### DIFF
--- a/k8s/deployment/templates/istio/blue-green-httproute.yaml.tpl
+++ b/k8s/deployment/templates/istio/blue-green-httproute.yaml.tpl
@@ -28,6 +28,7 @@ metadata:
   {{- end }}
 {{- end }}
   annotations:
+    external-dns.alpha.kubernetes.io/visibility: {{ if eq .ingress_visibility "internet-facing" }}public{{ else }}private{{ end }}
 {{- $global := index .k8s_modifiers "global" }}
 {{- if $global }}
   {{- $annotations := index $global "annotations" }}

--- a/k8s/deployment/templates/istio/initial-httproute.yaml.tpl
+++ b/k8s/deployment/templates/istio/initial-httproute.yaml.tpl
@@ -28,6 +28,7 @@ metadata:
   {{- end }}
 {{- end }}
   annotations:
+    external-dns.alpha.kubernetes.io/visibility: {{ if eq .ingress_visibility "internet-facing" }}public{{ else }}private{{ end }}
 {{- $global := index .k8s_modifiers "global" }}
 {{- if $global }}
   {{- $annotations := index $global "annotations" }}

--- a/k8s/scope/build_context
+++ b/k8s/scope/build_context
@@ -193,7 +193,7 @@ if [ "$SCOPE_VISIBILITY" = "public" ]; then
     )
 else
     export INGRESS_VISIBILITY="internal"
-    GATEWAY_DEFAULT="${PRIVATE_GATEWAY_NAME:-gateway-internal}"
+    GATEWAY_DEFAULT="${PRIVATE_GATEWAY_NAME:-gateway-private}"
     export GATEWAY_NAME=$(get_config_value \
       --provider '.providers["scope-configurations"].networking.gateway_private_name' \
       --provider '.providers["container-orchestration"].gateway.private_name' \


### PR DESCRIPTION
## Summary

- Add `external-dns.alpha.kubernetes.io/visibility` annotation to both HTTPRoute templates (initial and blue-green)
- Fix default private gateway name from `gateway-internal` → `gateway-private` in `build_context`

## Changes

### `k8s/deployment/templates/istio/initial-httproute.yaml.tpl`
### `k8s/deployment/templates/istio/blue-green-httproute.yaml.tpl`

Added annotation derived from `ingress_visibility`:
```yaml
annotations:
  external-dns.alpha.kubernetes.io/visibility: {{ if eq .ingress_visibility "internet-facing" }}public{{ else }}private{{ end }}
```

### `k8s/scope/build_context`

Changed the hardcoded default for the private gateway from `gateway-internal` to `gateway-private`, which matches the actual `Gateway` resource name created by the nullplatform base Helm chart. The `PRIVATE_GATEWAY_NAME` env var still overrides this when set explicitly.

## Motivation

When running two ExternalDNS instances (one for the public zone, one for the private zone), each instance needs to know which HTTPRoutes it should manage. Without the annotation, both instances process all HTTPRoutes and create duplicate DNS records in both zones.

With `--annotation-filter=external-dns.alpha.kubernetes.io/visibility=public` on the public instance and `=private` on the private instance, each only creates records for matching resources.

The `ingress_visibility` context variable already carries the right signal (`internet-facing` vs `internal`), so no new scope configuration is required.

## Backward compatibility

- The annotation is always emitted — no opt-in required. Existing ExternalDNS deployments without `--annotation-filter` ignore annotations by default and continue working unchanged.
- `gateway-private` is the correct name in all nullplatform-managed EKS clusters. Deployments that set `PRIVATE_GATEWAY_NAME` explicitly are unaffected.

## Test plan

- [ ] Deploy an `internet-facing` scope — verify HTTPRoute has `visibility: public` and DNS record appears only in the public zone
- [ ] Deploy an `internal` scope — verify HTTPRoute has `visibility: private` and DNS record appears only in the private zone
- [ ] Verify internal scopes route through `gateway-private` (not `gateway-internal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)