### PR TITLE
Structured evidence + log embedding in k8s/diagnose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public and private scopes now register DNS records in their correct Route53 hosted zone when using `DNS_TYPE=external_dns`, preventing cross-zone record leakage
 - Add configurable main HTTP port for k8s scopes (default 8080) and HTTP support for additional ports
 - Improve **wait deployment active** failure logging: consolidate repeated `Unhealthy` probe events per pod into a single human-readable line, emit a progress heartbeat every 10% of timeout, and surface a targeted suggested fix based on the probe failure mode (port not open / HTTP non-2xx / probe timeout)
+- Improve **k8s/diagnose** for AI post-mortem: every check now emits structured evidence following a documented schema (`summary`, `severity`, `affected`, `details`, `suggested_actions`), failure findings embed the relevant pod log slice (current or previous depending on the failure mode), and a new **Application Logs** category surfaces the user-owned `application` container's log tail directly in the UI
 
 ## [1.11.0] - 2026-04-16
 - Add unit testing support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public and private scopes now register DNS records in their correct Route53 hosted zone when using `DNS_TYPE=external_dns`, preventing cross-zone record leakage
 - Add configurable main HTTP port for k8s scopes (default 8080) and HTTP support for additional ports
 - Improve **wait deployment active** failure logging: consolidate repeated `Unhealthy` probe events per pod into a single human-readable line, emit a progress heartbeat every 10% of timeout, and surface a targeted suggested fix based on the probe failure mode (port not open / HTTP non-2xx / probe timeout)
-- Improve **k8s/diagnose** for AI post-mortem: every check now emits structured evidence following a documented schema (`summary`, `severity`, `affected`, `details`, `suggested_actions`), failure findings embed the relevant pod log slice (current or previous depending on the failure mode), and a new **Application Logs** category surfaces the user-owned `application` container's log tail directly in the UI
+- Improve **k8s/diagnose** evidence: every check now emits structured evidence following a documented schema (`summary`, `severity`, `affected`, `details`, `suggested_actions`), failure findings embed the relevant pod log slice (current or previous depending on the failure mode), and a new **Application Logs** category surfaces the user-owned `application` container's log tail directly in the UI
 
 ## [1.11.0] - 2026-04-16
 - Add unit testing support

--- a/k8s/deployment/workflows/diagnose.yaml
+++ b/k8s/deployment/workflows/diagnose.yaml
@@ -35,3 +35,4 @@ steps:
       - "$SERVICE_PATH/diagnose/service"
       - "$SERVICE_PATH/diagnose/scope"
       - "$SERVICE_PATH/diagnose/networking"
+      - "$SERVICE_PATH/diagnose/logs"

--- a/k8s/diagnose/build_context
+++ b/k8s/diagnose/build_context
@@ -29,6 +29,16 @@ PODS_FILE="$DATA_DIR/pods.json"
 kubectl get pods -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o json 2>/dev/null > "$PODS_FILE" || echo '{"items":[]}' > "$PODS_FILE"
 export PODS_FILE
 
+# Deployments
+DEPLOYMENTS_FILE="$DATA_DIR/deployments.json"
+kubectl get deployment -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o json 2>/dev/null > "$DEPLOYMENTS_FILE" || echo '{"items":[]}' > "$DEPLOYMENTS_FILE"
+export DEPLOYMENTS_FILE
+
+# ReplicaSets
+REPLICASETS_FILE="$DATA_DIR/replicasets.json"
+kubectl get rs -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o json 2>/dev/null > "$REPLICASETS_FILE" || echo '{"items":[]}' > "$REPLICASETS_FILE"
+export REPLICASETS_FILE
+
 # Services
 SERVICES_FILE="$DATA_DIR/services.json"
 kubectl get services -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o json 2>/dev/null > "$SERVICES_FILE" || echo '{"items":[]}' > "$SERVICES_FILE"
@@ -83,3 +93,78 @@ if [[ -n "$ALB_POD_NAMES" ]]; then
         kubectl logs "$POD_NAME" -n "$ALB_CONTROLLER_NAMESPACE" --tail=200 2>/dev/null > "$ALB_CONTROLLER_LOGS_DIR/${POD_NAME}.log" || echo "" > "$ALB_CONTROLLER_LOGS_DIR/${POD_NAME}.log"
     done
 fi
+
+# Identify problematic pods and capture their logs + describe
+# A pod is "problematic" if any of:
+#   - phase is not Running and not Succeeded
+#   - it is being deleted (deletionTimestamp present)
+#   - Ready condition is not True
+#   - any container (init or regular) has crashed, restarted, terminated, or is in a known error waiting state
+PROBLEMATIC_PODS_FILE="$DATA_DIR/problematic_pods.txt"
+POD_LOGS_DIR="$DATA_DIR/pod_logs"
+POD_DESCRIBE_DIR="$DATA_DIR/pod_describe"
+mkdir -p "$POD_LOGS_DIR" "$POD_DESCRIBE_DIR"
+
+POD_LOG_TAIL_LINES="${POD_LOG_TAIL_LINES:-500}"
+
+PROBLEMATIC_POD_NAMES=$(jq -r '
+  def is_error_waiting(reason):
+    reason | IN("CrashLoopBackOff","ImagePullBackOff","ErrImagePull","CreateContainerError","RunContainerError","CreateContainerConfigError");
+
+  def container_unhealthy(c):
+    (c.restartCount // 0) > 0
+    or (c.state.terminated // null) != null
+    or (c.lastState.terminated // null) != null
+    or (c.state.waiting // null) != null and is_error_waiting(c.state.waiting.reason // "");
+
+  .items[]
+  | select(
+      (.status.phase != "Running" and .status.phase != "Succeeded")
+      or (.metadata.deletionTimestamp // null) != null
+      or ((.status.conditions // []) | any(.type == "Ready" and .status != "True"))
+      or ((.status.containerStatuses // []) | any(container_unhealthy(.)))
+      or ((.status.initContainerStatuses // []) | any(container_unhealthy(.)))
+    )
+  | .metadata.name
+' "$PODS_FILE" 2>/dev/null)
+
+echo "$PROBLEMATIC_POD_NAMES" > "$PROBLEMATIC_PODS_FILE"
+export PROBLEMATIC_PODS_FILE
+export POD_LOGS_DIR
+export POD_DESCRIBE_DIR
+export POD_LOG_TAIL_LINES
+
+if [[ -n "$PROBLEMATIC_POD_NAMES" ]]; then
+    for POD_NAME in $PROBLEMATIC_POD_NAMES; do
+        # Describe (full output, includes spec + status + events correlated)
+        kubectl describe pod "$POD_NAME" -n "$NAMESPACE" > "$POD_DESCRIBE_DIR/${POD_NAME}.txt" 2>/dev/null || echo "" > "$POD_DESCRIBE_DIR/${POD_NAME}.txt"
+
+        # Capture logs for every container (init + regular), current and previous
+        ALL_CONTAINERS=$(jq -r --arg name "$POD_NAME" '
+            .items[]
+            | select(.metadata.name == $name)
+            | ((.spec.initContainers // []) + (.spec.containers // []))
+            | .[].name
+        ' "$PODS_FILE" 2>/dev/null)
+
+        for CONTAINER_NAME in $ALL_CONTAINERS; do
+            CURRENT_LOG="$POD_LOGS_DIR/${POD_NAME}.${CONTAINER_NAME}.log"
+            PREVIOUS_LOG="$POD_LOGS_DIR/${POD_NAME}.${CONTAINER_NAME}.previous.log"
+
+            # Current container logs (always kept, even if empty: "container produced no output yet" is meaningful)
+            kubectl logs "$POD_NAME" -n "$NAMESPACE" -c "$CONTAINER_NAME" --tail="$POD_LOG_TAIL_LINES" \
+                > "$CURRENT_LOG" 2>/dev/null || echo "" > "$CURRENT_LOG"
+
+            # Previous container logs (kubectl exits 1 when there is no previous instance — expected, ignore)
+            kubectl logs "$POD_NAME" -n "$NAMESPACE" -c "$CONTAINER_NAME" --tail="$POD_LOG_TAIL_LINES" --previous \
+                > "$PREVIOUS_LOG" 2>/dev/null || true
+            if [[ ! -s "$PREVIOUS_LOG" ]]; then
+                rm -f "$PREVIOUS_LOG"
+            fi
+        done
+    done
+fi
+
+# Always end with success: build_context is sourced, and a trailing non-zero status
+# from any conditional above would propagate to the caller.
+:

--- a/k8s/diagnose/logs/application_log_evidence
+++ b/k8s/diagnose/logs/application_log_evidence
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Check: Application Log Evidence
 #
-# Purpose: capture the logs of the user-owned "application" container from
-# each problematic pod so the AI post-mortem summarizer has a focused,
-# self-contained source for application output to analyze.
+# Purpose: surface the logs of the user-owned "application" container from
+# each problematic pod so they are visible in the diagnose UI's check.logs[]
+# view (the last 20 stdout lines of the check).
 #
 # Scope is intentionally narrow:
 #   - Only the container literally named "application" (the user code; see
@@ -11,12 +11,13 @@
 #     nginx) and init containers are out of scope here — the scope/ checks
 #     already report their findings without us duplicating logs across
 #     containers and probe rounds.
-#   - Evidence payload is just the logs (current + previous) plus the pod
-#     name. Pod/container state is already published by the scope/ checks;
-#     re-emitting it would inflate the payload without adding information.
+#   - Logs are echoed to stdout only; the evidence payload carries only
+#     counters and the list of pods (in evidence.affected). Re-emitting the
+#     log text inside evidence.details would duplicate what already lives in
+#     the check's logs[] tail.
 #
 # Reads from the build_context snapshot (data/pod_logs/), never calls kubectl.
-# Severity is always "info"; this check publishes evidence, it does not detect
+# Severity is always "info"; this check publishes context, it does not detect
 # failure modes.
 
 APPLICATION_CONTAINER_NAME="application"
@@ -27,7 +28,7 @@ if [[ ! -f "$PROBLEMATIC_PODS_FILE" ]]; then
         "Snapshot unavailable, log collection skipped" \
         "info" \
         "[]" \
-        '{"pods": []}' \
+        "$(jq -nc '{pods_with_logs: 0, problematic_pod_count: 0}')" \
         "[]")
     update_check_result --status "skipped" --evidence "$SKIP_EVIDENCE"
     return 0
@@ -38,12 +39,12 @@ PROBLEMATIC_PODS=$(grep -v '^[[:space:]]*$' "$PROBLEMATIC_PODS_FILE" 2>/dev/null
 if [[ -z "$PROBLEMATIC_PODS" ]]; then
     print_success "No problematic pods detected — no application logs to collect"
     SUMMARY="No problematic pods detected, no application logs to collect"
-    EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" '{"pods": []}' "[]")
+    DETAILS=$(jq -nc '{pods_with_logs: 0, problematic_pod_count: 0}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" "$DETAILS" "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
     return 0
 fi
 
-POD_FACTS=()
 AFFECTED_PODS=""
 PODS_WITH_LOGS=0
 TOTAL_PROBLEMATIC=$(echo "$PROBLEMATIC_PODS" | wc -w | tr -d ' ')
@@ -80,30 +81,32 @@ for POD_NAME in $PROBLEMATIC_PODS; do
         continue
     fi
 
-    FACT=$(jq -nc \
-        --arg pod "$POD_NAME" \
-        --argjson logs "$MERGED_LOGS" \
-        '{
-            pod: $pod,
-            logs: $logs
-        }')
-    add_fact POD_FACTS "$FACT"
     mark_affected AFFECTED_PODS "$POD_NAME"
     PODS_WITH_LOGS=$((PODS_WITH_LOGS + 1))
-    print_info "Collected application logs from pod $POD_NAME"
+
+    # Echo the log tail to stdout so it surfaces in the UI's check.logs view
+    # (update_check_result captures the last 20 non-empty stdout lines). This
+    # is the only place the log text lives — evidence.details stores only
+    # counters, so there is no duplication between evidence and logs[].
+    print_info "─── application log tail from $POD_NAME ───"
+    echo "$MERGED_LOGS" | jq -r '.[] | "  | \(.)"'
 done
 
-POD_FACTS_JSON=$(facts_to_json_array POD_FACTS)
 AFFECTED_PODS_JSON=$(set_to_json_array AFFECTED_PODS)
 
 if [[ $PODS_WITH_LOGS -eq 0 ]]; then
     SUMMARY="No application logs available across $TOTAL_PROBLEMATIC problematic pod(s) — image may never have started"
-    DETAILS=$(jq -nc '{pods: []}')
+    DETAILS=$(jq -nc \
+        --argjson problematic "$TOTAL_PROBLEMATIC" \
+        '{pods_with_logs: 0, problematic_pod_count: $problematic}')
     EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" "$DETAILS" "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="Collected application logs from $PODS_WITH_LOGS of $TOTAL_PROBLEMATIC problematic pod(s)"
-    DETAILS=$(jq -nc --argjson pods "$POD_FACTS_JSON" '{pods: $pods}')
+    DETAILS=$(jq -nc \
+        --argjson with_logs "$PODS_WITH_LOGS" \
+        --argjson problematic "$TOTAL_PROBLEMATIC" \
+        '{pods_with_logs: $with_logs, problematic_pod_count: $problematic}')
     EVIDENCE=$(evidence_json "$SUMMARY" "info" "$AFFECTED_PODS_JSON" "$DETAILS" "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
     print_success "$SUMMARY"

--- a/k8s/diagnose/logs/application_log_evidence
+++ b/k8s/diagnose/logs/application_log_evidence
@@ -41,7 +41,7 @@ if [[ -z "$PROBLEMATIC_PODS" ]]; then
     SUMMARY="No problematic pods detected, no application logs to collect"
     DETAILS=$(jq -nc '{pods_with_logs: 0, problematic_pod_count: 0}')
     EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" "$DETAILS" "[]")
-    update_check_result --status "success" --evidence "$EVIDENCE"
+    update_check_result --status "success" --evidence "$EVIDENCE" --log-tail-lines 200
     return 0
 fi
 
@@ -84,9 +84,10 @@ for POD_NAME in $PROBLEMATIC_PODS; do
     mark_affected AFFECTED_PODS "$POD_NAME"
     PODS_WITH_LOGS=$((PODS_WITH_LOGS + 1))
 
-    # Echo the log tail to stdout so it surfaces in the UI's check.logs view
-    # (update_check_result captures the last 20 non-empty stdout lines). This
-    # is the only place the log text lives — evidence.details stores only
+    # Echo the log tail to stdout so it surfaces in the UI's check.logs view.
+    # update_check_result is called below with --log-tail-lines 200 so the cap
+    # accommodates the application log payload (default cap is 20). This is
+    # the only place the log text lives — evidence.details stores only
     # counters, so there is no duplication between evidence and logs[].
     print_info "─── application log tail from $POD_NAME ───"
     echo "$MERGED_LOGS" | jq -r '.[] | "  | \(.)"'
@@ -100,7 +101,7 @@ if [[ $PODS_WITH_LOGS -eq 0 ]]; then
         --argjson problematic "$TOTAL_PROBLEMATIC" \
         '{pods_with_logs: 0, problematic_pod_count: $problematic}')
     EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" "$DETAILS" "[]")
-    update_check_result --status "success" --evidence "$EVIDENCE"
+    update_check_result --status "success" --evidence "$EVIDENCE" --log-tail-lines 200
 else
     SUMMARY="Collected application logs from $PODS_WITH_LOGS of $TOTAL_PROBLEMATIC problematic pod(s)"
     DETAILS=$(jq -nc \
@@ -108,6 +109,6 @@ else
         --argjson problematic "$TOTAL_PROBLEMATIC" \
         '{pods_with_logs: $with_logs, problematic_pod_count: $problematic}')
     EVIDENCE=$(evidence_json "$SUMMARY" "info" "$AFFECTED_PODS_JSON" "$DETAILS" "[]")
-    update_check_result --status "success" --evidence "$EVIDENCE"
+    update_check_result --status "success" --evidence "$EVIDENCE" --log-tail-lines 200
     print_success "$SUMMARY"
 fi

--- a/k8s/diagnose/logs/application_log_evidence
+++ b/k8s/diagnose/logs/application_log_evidence
@@ -1,29 +1,33 @@
 #!/bin/bash
 # Check: Application Log Evidence
 #
-# Purpose: surface the application's own log output, contextualized with the
-# pod/container state at fail-time, as structured evidence for the AI
-# post-mortem summarizer. Unlike the scope/ checks that detect specific
-# failure modes and embed logs as secondary evidence, this check is log-first:
-# its only job is to publish "here are the logs, here is the context, look at
-# this" in a single, self-contained category.
+# Purpose: capture the logs of the user-owned "application" container from
+# each problematic pod so the AI post-mortem summarizer has a focused,
+# self-contained source for application output to analyze.
 #
-# Reads from the pre-collected snapshot taken by build_context (data/pod_logs/
-# and data/problematic_pods.txt). Never calls kubectl directly — the snapshot
-# was point-in-time at fail-time, before any rollback churned the cluster.
+# Scope is intentionally narrow:
+#   - Only the container literally named "application" (the user code; see
+#     k8s/deployment/templates/deployment.yaml.tpl). Sidecars (e.g. "http"
+#     nginx) and init containers are out of scope here — the scope/ checks
+#     already report their findings without us duplicating logs across
+#     containers and probe rounds.
+#   - Evidence payload is just the logs (current + previous) plus the pod
+#     name. Pod/container state is already published by the scope/ checks;
+#     re-emitting it would inflate the payload without adding information.
 #
-# Severity is always "info". The check never fails because absence of logs is
-# itself meaningful information (the AI can flag "image never started, no logs
-# to inspect, look at scope/image_pull_status").
+# Reads from the build_context snapshot (data/pod_logs/), never calls kubectl.
+# Severity is always "info"; this check publishes evidence, it does not detect
+# failure modes.
 
-# No problematic pods snapshot: build_context did not run or this is a test.
+APPLICATION_CONTAINER_NAME="application"
+
 if [[ ! -f "$PROBLEMATIC_PODS_FILE" ]]; then
     print_warning "No problematic pods snapshot available, log evidence skipped"
     SKIP_EVIDENCE=$(evidence_json \
         "Snapshot unavailable, log collection skipped" \
         "info" \
         "[]" \
-        "$(jq -nc '{pods_with_logs: 0, containers_with_logs: 0, logs: []}')" \
+        '{"pods": []}' \
         "[]")
     update_check_result --status "skipped" --evidence "$SKIP_EVIDENCE"
     return 0
@@ -32,202 +36,74 @@ fi
 PROBLEMATIC_PODS=$(grep -v '^[[:space:]]*$' "$PROBLEMATIC_PODS_FILE" 2>/dev/null)
 
 if [[ -z "$PROBLEMATIC_PODS" ]]; then
-    print_success "No problematic pods detected — no logs to collect"
+    print_success "No problematic pods detected — no application logs to collect"
     SUMMARY="No problematic pods detected, no application logs to collect"
-    DETAILS=$(jq -nc '{pods_with_logs: 0, containers_with_logs: 0, logs: []}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" "$DETAILS" "[]")
+    EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" '{"pods": []}' "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
     return 0
 fi
 
-LOG_FACTS=()
+POD_FACTS=()
 AFFECTED_PODS=""
-TOTAL_CONTAINERS=0
-TOTAL_PODS_WITH_LOGS=0
-PROBLEMATIC_POD_COUNT=$(echo "$PROBLEMATIC_PODS" | wc -w | tr -d ' ')
-
-# Extract pod-level context (phase + reason) in a single jq call.
-# Echoes a compact JSON object: {pod_phase, pod_reason}. pod_reason may be null.
-extract_pod_context() {
-    local pod="$1"
-    jq -c --arg pod "$pod" '
-        .items[]
-        | select(.metadata.name == $pod)
-        | {
-            pod_phase: (.status.phase // "Unknown"),
-            pod_reason: (
-                ((.status.conditions // [])
-                    | map(select(.type == "Ready" and .status != "True"))
-                    | .[0].reason)
-                // .status.reason
-                // null
-            )
-          }
-    ' "$PODS_FILE" 2>/dev/null
-}
-
-# Extract container-level context (state, restarts, last termination) for one
-# container, considering whether it lives under containerStatuses (regular) or
-# initContainerStatuses (init). Echoes a compact JSON object.
-extract_container_context() {
-    local pod="$1"
-    local container="$2"
-    local is_init="$3"  # "true" or "false"
-    local statuses_field
-    if [[ "$is_init" == "true" ]]; then
-        statuses_field="initContainerStatuses"
-    else
-        statuses_field="containerStatuses"
-    fi
-    jq -c --arg pod "$pod" --arg cn "$container" --arg sf "$statuses_field" '
-        .items[]
-        | select(.metadata.name == $pod)
-        | ((.status[$sf] // []) | map(select(.name == $cn)) | .[0] // {}) as $cs
-        | {
-            container_state: (
-                if $cs.state.waiting then "waiting"
-                elif $cs.state.terminated then "terminated"
-                elif $cs.state.running then "running"
-                else "unknown"
-                end
-            ),
-            restart_count: ($cs.restartCount // 0),
-            current_state_reason: ($cs.state.waiting.reason // $cs.state.terminated.reason // null),
-            last_termination_reason: ($cs.lastState.terminated.reason // null),
-            last_exit_code: ($cs.lastState.terminated.exitCode // null)
-          }
-    ' "$PODS_FILE" 2>/dev/null
-}
-
-# Inner helper: read current + previous logs for one container plus its
-# context, build a fact JSON, and bump the counters. Returns 0 if a fact was
-# added, 1 if the container produced no logs at all (skipped).
-collect_container_logs() {
-    local pod="$1"
-    local container="$2"
-    local is_init="$3"
-    local pod_phase="$4"
-    local pod_reason="$5"
-    local current_logs previous_logs current_count previous_count
-
-    current_logs=$(read_log_tail "$pod" "$container" "current")
-    previous_logs=$(read_log_tail "$pod" "$container" "previous")
-    current_count=$(echo "$current_logs" | jq 'length')
-    previous_count=$(echo "$previous_logs" | jq 'length')
-
-    if [[ "$current_count" -eq 0 && "$previous_count" -eq 0 ]]; then
-        return 1
-    fi
-
-    local container_ctx last_exit_code last_exit_meaning
-    container_ctx=$(extract_container_context "$pod" "$container" "$is_init")
-    last_exit_code=$(echo "$container_ctx" | jq -r '.last_exit_code // empty')
-    if [[ -n "$last_exit_code" ]]; then
-        last_exit_meaning=$(exit_code_meaning "$last_exit_code")
-    else
-        last_exit_meaning=""
-    fi
-
-    local fact
-    fact=$(jq -nc \
-        --arg pod "$pod" \
-        --arg pod_phase "$pod_phase" \
-        --arg pod_reason "$pod_reason" \
-        --arg container "$container" \
-        --argjson is_init "$is_init" \
-        --argjson container_ctx "$container_ctx" \
-        --arg last_exit_meaning "$last_exit_meaning" \
-        --argjson current_logs "$current_logs" \
-        --argjson previous_logs "$previous_logs" \
-        '{
-            pod: $pod,
-            pod_phase: $pod_phase,
-            pod_reason: (if ($pod_reason | length) == 0 then null else $pod_reason end),
-            container: $container,
-            init_container: $is_init,
-            container_state: $container_ctx.container_state,
-            restart_count: $container_ctx.restart_count,
-            current_state_reason: $container_ctx.current_state_reason,
-            last_termination_reason: $container_ctx.last_termination_reason,
-            last_exit_code: $container_ctx.last_exit_code,
-            last_exit_code_meaning: (if ($last_exit_meaning | length) == 0 then null else $last_exit_meaning end),
-            current_logs: $current_logs,
-            previous_logs: $previous_logs
-        }')
-    add_fact LOG_FACTS "$fact"
-    TOTAL_CONTAINERS=$((TOTAL_CONTAINERS + 1))
-    return 0
-}
+PODS_WITH_LOGS=0
+TOTAL_PROBLEMATIC=$(echo "$PROBLEMATIC_PODS" | wc -w | tr -d ' ')
 
 for POD_NAME in $PROBLEMATIC_PODS; do
-    POD_HAS_LOGS=0
-
-    POD_CTX=$(extract_pod_context "$POD_NAME")
-    POD_PHASE=$(echo "$POD_CTX" | jq -r '.pod_phase')
-    POD_REASON=$(echo "$POD_CTX" | jq -r '.pod_reason // empty')
-
-    INIT_CONTAINERS=$(jq -r --arg name "$POD_NAME" '
-        .items[]
-        | select(.metadata.name == $name)
-        | (.spec.initContainers // [])
-        | .[].name
-    ' "$PODS_FILE" 2>/dev/null)
-
-    REGULAR_CONTAINERS=$(jq -r --arg name "$POD_NAME" '
+    HAS_APP_CONTAINER=$(jq -r --arg name "$POD_NAME" --arg cn "$APPLICATION_CONTAINER_NAME" '
         .items[]
         | select(.metadata.name == $name)
         | (.spec.containers // [])
-        | .[].name
+        | map(.name)
+        | index($cn) != null
     ' "$PODS_FILE" 2>/dev/null)
 
-    for CONTAINER in $INIT_CONTAINERS; do
-        if collect_container_logs "$POD_NAME" "$CONTAINER" "true" "$POD_PHASE" "$POD_REASON"; then
-            POD_HAS_LOGS=1
-        fi
-    done
-    for CONTAINER in $REGULAR_CONTAINERS; do
-        if collect_container_logs "$POD_NAME" "$CONTAINER" "false" "$POD_PHASE" "$POD_REASON"; then
-            POD_HAS_LOGS=1
-        fi
-    done
-
-    if [[ $POD_HAS_LOGS -eq 1 ]]; then
-        mark_affected AFFECTED_PODS "$POD_NAME"
-        TOTAL_PODS_WITH_LOGS=$((TOTAL_PODS_WITH_LOGS + 1))
-        print_info "Collected logs from pod $POD_NAME ($POD_PHASE)"
-    else
-        print_warning "Pod $POD_NAME ($POD_PHASE) is problematic but produced no logs (image never started?)"
+    if [[ "$HAS_APP_CONTAINER" != "true" ]]; then
+        print_warning "Pod $POD_NAME has no '$APPLICATION_CONTAINER_NAME' container — skipped"
+        continue
     fi
+
+    CURRENT_LOGS=$(read_log_tail "$POD_NAME" "$APPLICATION_CONTAINER_NAME" "current")
+    PREVIOUS_LOGS=$(read_log_tail "$POD_NAME" "$APPLICATION_CONTAINER_NAME" "previous")
+
+    # Merge previous + current in chronological order, then keep only the last
+    # N lines (defaults to 50). One flat array; the AI does not need to know
+    # which container instance produced which line.
+    TAIL_LINES="${EVIDENCE_LOG_TAIL_LINES:-50}"
+    MERGED_LOGS=$(jq -nc \
+        --argjson prev "$PREVIOUS_LOGS" \
+        --argjson curr "$CURRENT_LOGS" \
+        --argjson n "$TAIL_LINES" \
+        '($prev + $curr) | .[-$n:]')
+
+    if [[ "$(echo "$MERGED_LOGS" | jq 'length')" -eq 0 ]]; then
+        print_warning "Pod $POD_NAME application container produced no logs"
+        continue
+    fi
+
+    FACT=$(jq -nc \
+        --arg pod "$POD_NAME" \
+        --argjson logs "$MERGED_LOGS" \
+        '{
+            pod: $pod,
+            logs: $logs
+        }')
+    add_fact POD_FACTS "$FACT"
+    mark_affected AFFECTED_PODS "$POD_NAME"
+    PODS_WITH_LOGS=$((PODS_WITH_LOGS + 1))
+    print_info "Collected application logs from pod $POD_NAME"
 done
 
-LOG_FACTS_JSON=$(facts_to_json_array LOG_FACTS)
+POD_FACTS_JSON=$(facts_to_json_array POD_FACTS)
 AFFECTED_PODS_JSON=$(set_to_json_array AFFECTED_PODS)
 
-if [[ $TOTAL_CONTAINERS -eq 0 ]]; then
-    SUMMARY="No application logs available across $PROBLEMATIC_POD_COUNT problematic pod(s) — image may never have started"
-    DETAILS=$(jq -nc \
-        --argjson problematic "$PROBLEMATIC_POD_COUNT" \
-        '{
-            pods_with_logs: 0,
-            containers_with_logs: 0,
-            problematic_pod_count: $problematic,
-            logs: []
-        }')
+if [[ $PODS_WITH_LOGS -eq 0 ]]; then
+    SUMMARY="No application logs available across $TOTAL_PROBLEMATIC problematic pod(s) — image may never have started"
+    DETAILS=$(jq -nc '{pods: []}')
     EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" "$DETAILS" "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    SUMMARY="Collected logs from $TOTAL_CONTAINERS container(s) across $TOTAL_PODS_WITH_LOGS of $PROBLEMATIC_POD_COUNT problematic pod(s)"
-    DETAILS=$(jq -nc \
-        --argjson pods_with_logs "$TOTAL_PODS_WITH_LOGS" \
-        --argjson containers_with_logs "$TOTAL_CONTAINERS" \
-        --argjson problematic "$PROBLEMATIC_POD_COUNT" \
-        --argjson logs "$LOG_FACTS_JSON" \
-        '{
-            pods_with_logs: $pods_with_logs,
-            containers_with_logs: $containers_with_logs,
-            problematic_pod_count: $problematic,
-            logs: $logs
-        }')
+    SUMMARY="Collected application logs from $PODS_WITH_LOGS of $TOTAL_PROBLEMATIC problematic pod(s)"
+    DETAILS=$(jq -nc --argjson pods "$POD_FACTS_JSON" '{pods: $pods}')
     EVIDENCE=$(evidence_json "$SUMMARY" "info" "$AFFECTED_PODS_JSON" "$DETAILS" "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
     print_success "$SUMMARY"

--- a/k8s/diagnose/logs/application_log_evidence
+++ b/k8s/diagnose/logs/application_log_evidence
@@ -1,0 +1,234 @@
+#!/bin/bash
+# Check: Application Log Evidence
+#
+# Purpose: surface the application's own log output, contextualized with the
+# pod/container state at fail-time, as structured evidence for the AI
+# post-mortem summarizer. Unlike the scope/ checks that detect specific
+# failure modes and embed logs as secondary evidence, this check is log-first:
+# its only job is to publish "here are the logs, here is the context, look at
+# this" in a single, self-contained category.
+#
+# Reads from the pre-collected snapshot taken by build_context (data/pod_logs/
+# and data/problematic_pods.txt). Never calls kubectl directly — the snapshot
+# was point-in-time at fail-time, before any rollback churned the cluster.
+#
+# Severity is always "info". The check never fails because absence of logs is
+# itself meaningful information (the AI can flag "image never started, no logs
+# to inspect, look at scope/image_pull_status").
+
+# No problematic pods snapshot: build_context did not run or this is a test.
+if [[ ! -f "$PROBLEMATIC_PODS_FILE" ]]; then
+    print_warning "No problematic pods snapshot available, log evidence skipped"
+    SKIP_EVIDENCE=$(evidence_json \
+        "Snapshot unavailable, log collection skipped" \
+        "info" \
+        "[]" \
+        "$(jq -nc '{pods_with_logs: 0, containers_with_logs: 0, logs: []}')" \
+        "[]")
+    update_check_result --status "skipped" --evidence "$SKIP_EVIDENCE"
+    return 0
+fi
+
+PROBLEMATIC_PODS=$(grep -v '^[[:space:]]*$' "$PROBLEMATIC_PODS_FILE" 2>/dev/null)
+
+if [[ -z "$PROBLEMATIC_PODS" ]]; then
+    print_success "No problematic pods detected — no logs to collect"
+    SUMMARY="No problematic pods detected, no application logs to collect"
+    DETAILS=$(jq -nc '{pods_with_logs: 0, containers_with_logs: 0, logs: []}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" "$DETAILS" "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
+    return 0
+fi
+
+LOG_FACTS=()
+AFFECTED_PODS=""
+TOTAL_CONTAINERS=0
+TOTAL_PODS_WITH_LOGS=0
+PROBLEMATIC_POD_COUNT=$(echo "$PROBLEMATIC_PODS" | wc -w | tr -d ' ')
+
+# Extract pod-level context (phase + reason) in a single jq call.
+# Echoes a compact JSON object: {pod_phase, pod_reason}. pod_reason may be null.
+extract_pod_context() {
+    local pod="$1"
+    jq -c --arg pod "$pod" '
+        .items[]
+        | select(.metadata.name == $pod)
+        | {
+            pod_phase: (.status.phase // "Unknown"),
+            pod_reason: (
+                ((.status.conditions // [])
+                    | map(select(.type == "Ready" and .status != "True"))
+                    | .[0].reason)
+                // .status.reason
+                // null
+            )
+          }
+    ' "$PODS_FILE" 2>/dev/null
+}
+
+# Extract container-level context (state, restarts, last termination) for one
+# container, considering whether it lives under containerStatuses (regular) or
+# initContainerStatuses (init). Echoes a compact JSON object.
+extract_container_context() {
+    local pod="$1"
+    local container="$2"
+    local is_init="$3"  # "true" or "false"
+    local statuses_field
+    if [[ "$is_init" == "true" ]]; then
+        statuses_field="initContainerStatuses"
+    else
+        statuses_field="containerStatuses"
+    fi
+    jq -c --arg pod "$pod" --arg cn "$container" --arg sf "$statuses_field" '
+        .items[]
+        | select(.metadata.name == $pod)
+        | ((.status[$sf] // []) | map(select(.name == $cn)) | .[0] // {}) as $cs
+        | {
+            container_state: (
+                if $cs.state.waiting then "waiting"
+                elif $cs.state.terminated then "terminated"
+                elif $cs.state.running then "running"
+                else "unknown"
+                end
+            ),
+            restart_count: ($cs.restartCount // 0),
+            current_state_reason: ($cs.state.waiting.reason // $cs.state.terminated.reason // null),
+            last_termination_reason: ($cs.lastState.terminated.reason // null),
+            last_exit_code: ($cs.lastState.terminated.exitCode // null)
+          }
+    ' "$PODS_FILE" 2>/dev/null
+}
+
+# Inner helper: read current + previous logs for one container plus its
+# context, build a fact JSON, and bump the counters. Returns 0 if a fact was
+# added, 1 if the container produced no logs at all (skipped).
+collect_container_logs() {
+    local pod="$1"
+    local container="$2"
+    local is_init="$3"
+    local pod_phase="$4"
+    local pod_reason="$5"
+    local current_logs previous_logs current_count previous_count
+
+    current_logs=$(read_log_tail "$pod" "$container" "current")
+    previous_logs=$(read_log_tail "$pod" "$container" "previous")
+    current_count=$(echo "$current_logs" | jq 'length')
+    previous_count=$(echo "$previous_logs" | jq 'length')
+
+    if [[ "$current_count" -eq 0 && "$previous_count" -eq 0 ]]; then
+        return 1
+    fi
+
+    local container_ctx last_exit_code last_exit_meaning
+    container_ctx=$(extract_container_context "$pod" "$container" "$is_init")
+    last_exit_code=$(echo "$container_ctx" | jq -r '.last_exit_code // empty')
+    if [[ -n "$last_exit_code" ]]; then
+        last_exit_meaning=$(exit_code_meaning "$last_exit_code")
+    else
+        last_exit_meaning=""
+    fi
+
+    local fact
+    fact=$(jq -nc \
+        --arg pod "$pod" \
+        --arg pod_phase "$pod_phase" \
+        --arg pod_reason "$pod_reason" \
+        --arg container "$container" \
+        --argjson is_init "$is_init" \
+        --argjson container_ctx "$container_ctx" \
+        --arg last_exit_meaning "$last_exit_meaning" \
+        --argjson current_logs "$current_logs" \
+        --argjson previous_logs "$previous_logs" \
+        '{
+            pod: $pod,
+            pod_phase: $pod_phase,
+            pod_reason: (if ($pod_reason | length) == 0 then null else $pod_reason end),
+            container: $container,
+            init_container: $is_init,
+            container_state: $container_ctx.container_state,
+            restart_count: $container_ctx.restart_count,
+            current_state_reason: $container_ctx.current_state_reason,
+            last_termination_reason: $container_ctx.last_termination_reason,
+            last_exit_code: $container_ctx.last_exit_code,
+            last_exit_code_meaning: (if ($last_exit_meaning | length) == 0 then null else $last_exit_meaning end),
+            current_logs: $current_logs,
+            previous_logs: $previous_logs
+        }')
+    add_fact LOG_FACTS "$fact"
+    TOTAL_CONTAINERS=$((TOTAL_CONTAINERS + 1))
+    return 0
+}
+
+for POD_NAME in $PROBLEMATIC_PODS; do
+    POD_HAS_LOGS=0
+
+    POD_CTX=$(extract_pod_context "$POD_NAME")
+    POD_PHASE=$(echo "$POD_CTX" | jq -r '.pod_phase')
+    POD_REASON=$(echo "$POD_CTX" | jq -r '.pod_reason // empty')
+
+    INIT_CONTAINERS=$(jq -r --arg name "$POD_NAME" '
+        .items[]
+        | select(.metadata.name == $name)
+        | (.spec.initContainers // [])
+        | .[].name
+    ' "$PODS_FILE" 2>/dev/null)
+
+    REGULAR_CONTAINERS=$(jq -r --arg name "$POD_NAME" '
+        .items[]
+        | select(.metadata.name == $name)
+        | (.spec.containers // [])
+        | .[].name
+    ' "$PODS_FILE" 2>/dev/null)
+
+    for CONTAINER in $INIT_CONTAINERS; do
+        if collect_container_logs "$POD_NAME" "$CONTAINER" "true" "$POD_PHASE" "$POD_REASON"; then
+            POD_HAS_LOGS=1
+        fi
+    done
+    for CONTAINER in $REGULAR_CONTAINERS; do
+        if collect_container_logs "$POD_NAME" "$CONTAINER" "false" "$POD_PHASE" "$POD_REASON"; then
+            POD_HAS_LOGS=1
+        fi
+    done
+
+    if [[ $POD_HAS_LOGS -eq 1 ]]; then
+        mark_affected AFFECTED_PODS "$POD_NAME"
+        TOTAL_PODS_WITH_LOGS=$((TOTAL_PODS_WITH_LOGS + 1))
+        print_info "Collected logs from pod $POD_NAME ($POD_PHASE)"
+    else
+        print_warning "Pod $POD_NAME ($POD_PHASE) is problematic but produced no logs (image never started?)"
+    fi
+done
+
+LOG_FACTS_JSON=$(facts_to_json_array LOG_FACTS)
+AFFECTED_PODS_JSON=$(set_to_json_array AFFECTED_PODS)
+
+if [[ $TOTAL_CONTAINERS -eq 0 ]]; then
+    SUMMARY="No application logs available across $PROBLEMATIC_POD_COUNT problematic pod(s) — image may never have started"
+    DETAILS=$(jq -nc \
+        --argjson problematic "$PROBLEMATIC_POD_COUNT" \
+        '{
+            pods_with_logs: 0,
+            containers_with_logs: 0,
+            problematic_pod_count: $problematic,
+            logs: []
+        }')
+    EVIDENCE=$(evidence_json "$SUMMARY" "info" "[]" "$DETAILS" "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
+else
+    SUMMARY="Collected logs from $TOTAL_CONTAINERS container(s) across $TOTAL_PODS_WITH_LOGS of $PROBLEMATIC_POD_COUNT problematic pod(s)"
+    DETAILS=$(jq -nc \
+        --argjson pods_with_logs "$TOTAL_PODS_WITH_LOGS" \
+        --argjson containers_with_logs "$TOTAL_CONTAINERS" \
+        --argjson problematic "$PROBLEMATIC_POD_COUNT" \
+        --argjson logs "$LOG_FACTS_JSON" \
+        '{
+            pods_with_logs: $pods_with_logs,
+            containers_with_logs: $containers_with_logs,
+            problematic_pod_count: $problematic,
+            logs: $logs
+        }')
+    EVIDENCE=$(evidence_json "$SUMMARY" "info" "$AFFECTED_PODS_JSON" "$DETAILS" "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
+    print_success "$SUMMARY"
+fi

--- a/k8s/diagnose/logs/workflow.yml
+++ b/k8s/diagnose/logs/workflow.yml
@@ -1,0 +1,6 @@
+steps:
+  - name: Application Log Evidence
+    description: Collects pod logs from the diagnose snapshot for AI post-mortem analysis
+    category: Application Logs
+    type: script
+    file: "$SERVICE_PATH/diagnose/logs/application_log_evidence"

--- a/k8s/diagnose/networking/alb_capacity_check
+++ b/k8s/diagnose/networking/alb_capacity_check
@@ -2,35 +2,42 @@
 # Check: ALB Capacity Check
 # Checks for common ALB issues (IP exhaustion, certificate problems)
 
-# Validate ingresses exist
 require_ingresses || return 0
 
-# Read ingresses from pre-collected data
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+ISSUE_FACTS="[]"
+INGRESS_FACTS="[]"
+AFFECTED_INGRESSES="[]"
+HAS_IP_EXHAUSTION=0
+IP_EXHAUSTION_LOGS="[]"
 
-# Get ALB controller pods from pre-collected data
+mark_affected() {
+    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
+}
+
 ALB_CONTROLLER_PODS=$(jq -r '.items[].metadata.name' "$ALB_CONTROLLER_PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
 if [[ -n "$ALB_CONTROLLER_PODS" ]]; then
     for POD in $ALB_CONTROLLER_PODS; do
-        # Look for IP exhaustion errors in pre-collected controller logs
         LOG_FILE="$ALB_CONTROLLER_LOGS_DIR/${POD}.log"
         if [[ -f "$LOG_FILE" ]] && [[ -r "$LOG_FILE" ]]; then
-            # Use tail and awk to handle massive log lines efficiently
             IP_ERRORS=$(tail -n 500 "$LOG_FILE" 2>/dev/null | \
                 awk 'length <= 10000' 2>/dev/null | \
                 grep -iE "no available ip|insufficient ip|ip address.*(exhausted|unavailable)" 2>/dev/null || true)
 
             if [[ -n "$IP_ERRORS" ]]; then
-                HAS_ISSUES=1
+                HAS_IP_EXHAUSTION=1
                 print_error "  ALB subnet IP exhaustion detected, Recent logs:"
                 if ! echo "$IP_ERRORS" | tail -n 3 2>/dev/null | cut -c1-200 2>/dev/null | sed 's/^/    /' 2>/dev/null; then
                     print_warning "    [Log details could not be displayed]"
                 fi
                 print_action "Check subnet CIDR ranges and consider expanding or using different subnets"
                 print_info "  Annotation: alb.ingress.kubernetes.io/subnets=<subnet-ids>"
+
+                TRUNC=$(echo "$IP_ERRORS" | tail -n 3 | cut -c1-200 | jq -R . | jq -s .)
+                IP_EXHAUSTION_LOGS=$(echo "$IP_EXHAUSTION_LOGS" | jq --arg pod "$POD" --argjson lines "$TRUNC" \
+                    '. + [{controller_pod: $pod, lines: $lines}]')
                 break
             fi
         elif [[ -e "$LOG_FILE" ]] && [[ ! -r "$LOG_FILE" ]]; then
@@ -38,22 +45,32 @@ if [[ -n "$ALB_CONTROLLER_PODS" ]]; then
         fi
     done
 
-    if [[ -z "$IP_ERRORS" ]]; then
+    if [[ $HAS_IP_EXHAUSTION -eq 0 ]]; then
         print_success "  No IP exhaustion issues detected"
     fi
 fi
 
-# Consolidated loop: check all ingress-related issues in one pass
-for INGRESS_NAME in $INGRESSES; do
-    # Get ingress info from pre-collected data (single read per ingress)
-    INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
+[[ $HAS_IP_EXHAUSTION -eq 1 ]] && {
+    ISSUE=$(jq -nc --argjson logs "$IP_EXHAUSTION_LOGS" \
+        '{issue: "subnet_ip_exhaustion", evidence_logs: $logs}')
+    ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+    # mark all ingresses as affected (cluster-wide issue)
+    for INGRESS_NAME in $INGRESSES; do mark_affected "$INGRESS_NAME"; done
+}
 
+for INGRESS_NAME in $INGRESSES; do
+    INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
     print_info "Checking ingress: $INGRESS_NAME"
 
-    # ===== TLS/Certificate Configuration Checks =====
+    INGRESS_HAS_ISSUE=0
     CERT_ARN=$(echo "$INGRESS_INFO" | jq -r '.metadata.annotations["alb.ingress.kubernetes.io/certificate-arn"] // empty')
     TLS_HOSTS=$(echo "$INGRESS_INFO" | jq -r '.spec.tls[]?.hosts[]?' 2>/dev/null)
     INGRESS_HOSTS=$(echo "$INGRESS_INFO" | jq -r '.spec.rules[]?.host' 2>/dev/null)
+    SCHEME=$(echo "$INGRESS_INFO" | jq -r '.metadata.annotations["alb.ingress.kubernetes.io/scheme"] // empty')
+    SUBNETS=$(echo "$INGRESS_INFO" | jq -r '.metadata.annotations["alb.ingress.kubernetes.io/subnets"] // empty')
+
+    CERT_ERROR_LINES="[]"
+    HOST_TLS_MISMATCHES="[]"
 
     if [[ -n "$TLS_HOSTS" || -n "$CERT_ARN" ]]; then
         print_info "  SSL/TLS configured"
@@ -61,42 +78,51 @@ for INGRESS_NAME in $INGRESSES; do
         if [[ -n "$CERT_ARN" ]]; then
             print_info "    Certificate ARN: $CERT_ARN"
 
-            # Check controller logs for certificate errors
             if [[ -n "$ALB_CONTROLLER_PODS" ]]; then
                 for POD in $ALB_CONTROLLER_PODS; do
                     LOG_FILE="$ALB_CONTROLLER_LOGS_DIR/${POD}.log"
                     if [[ -f "$LOG_FILE" ]] && [[ -r "$LOG_FILE" ]]; then
-                        # Use tail and awk to handle massive log lines efficiently
                         CERT_ERRORS=$(tail -n 500 "$LOG_FILE" 2>/dev/null | \
                             awk 'length <= 10000' 2>/dev/null | \
                             grep -iF "$INGRESS_NAME" 2>/dev/null | \
                             grep -iE "certificate.*(not found|invalid|failed|error)" 2>/dev/null || true)
 
                         if [[ -n "$CERT_ERRORS" ]]; then
-                            HAS_ISSUES=1
+                            mark_affected "$INGRESS_NAME"
+                            INGRESS_HAS_ISSUE=1
                             print_error "    Certificate validation errors found:"
                             if ! echo "$CERT_ERRORS" | tail -n 2 2>/dev/null | cut -c1-200 2>/dev/null | sed 's/^/      /' 2>/dev/null; then
                                 print_warning "      [Certificate error details could not be displayed]"
                             fi
                             print_action "Verify certificate ARN exists in ACM and covers the required domains"
+
+                            TRUNC=$(echo "$CERT_ERRORS" | tail -n 2 | cut -c1-200 | jq -R . | jq -s .)
+                            CERT_ERROR_LINES=$(echo "$CERT_ERROR_LINES" | jq --arg pod "$POD" --argjson lines "$TRUNC" \
+                                '. + [{controller_pod: $pod, lines: $lines}]')
+                            ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson lines "$TRUNC" \
+                                '{ingress: $ing, issue: "certificate_validation_errors", log_lines: $lines}')
+                            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
                         fi
                     fi
                 done
             fi
         fi
 
-        # Verify hosts match between rules and TLS
         if [[ -n "$TLS_HOSTS" && -n "$INGRESS_HOSTS" ]]; then
             for HOST in $INGRESS_HOSTS; do
                 if ! echo "$TLS_HOSTS" | grep -qw "$HOST"; then
-                    HAS_ISSUES=1
+                    mark_affected "$INGRESS_NAME"
+                    INGRESS_HAS_ISSUE=1
                     print_error "    Host '$HOST' in rules but not in TLS configuration"
                     print_action "Add host to spec.tls or ensure certificate covers this domain"
+                    HOST_TLS_MISMATCHES=$(echo "$HOST_TLS_MISMATCHES" | jq --arg h "$HOST" '. + [$h]')
+                    ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg host "$HOST" \
+                        '{ingress: $ing, host: $host, issue: "host_in_rules_not_in_tls"}')
+                    ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
                 fi
             done
         fi
 
-        # Check for missing certificate when TLS is configured
         if [[ -n "$TLS_HOSTS" && -z "$CERT_ARN" ]]; then
             print_warning "    TLS hosts configured but no ACM certificate ARN annotation"
             print_info "    Add annotation: alb.ingress.kubernetes.io/certificate-arn=<arn>"
@@ -105,8 +131,6 @@ for INGRESS_NAME in $INGRESSES; do
         print_info "  No SSL/TLS configured (HTTP only)"
     fi
 
-    # ===== Events Checks (subnet, security group, target group) =====
-    # Get events sorted by timestamp, most recent first
     EVENTS_JSON=$(jq --arg name "$INGRESS_NAME" --arg kind "Ingress" '
         .items
         | map(select(.involvedObject.name == $name and .involvedObject.kind == $kind))
@@ -114,65 +138,114 @@ for INGRESS_NAME in $INGRESSES; do
         | reverse
     ' "$EVENTS_FILE" 2>/dev/null)
 
+    SUBNET_ERROR_LINES="[]"
+    SG_ERROR_LINES="[]"
+    TG_ERROR_LINES="[]"
+
     EVENT_COUNT=$(echo "$EVENTS_JSON" | jq 'length' 2>/dev/null)
 
     if [[ "$EVENT_COUNT" -gt 0 ]]; then
-        # Get all error/warning events
-        ERROR_EVENTS=$(echo "$EVENTS_JSON" | jq -r '
-            .[]
-            | select(.type == "Warning" or .type == "Error")
-        ' 2>/dev/null)
+        ERROR_EVENTS=$(echo "$EVENTS_JSON" | jq -c '[.[] | select(.type == "Warning" or .type == "Error")]' 2>/dev/null)
 
-        if [[ -n "$ERROR_EVENTS" ]]; then
-            # Check for subnet errors
-            SUBNET_ERRORS=$(echo "$ERROR_EVENTS" | jq -r 'select(.message | test("subnet|availability zone"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
-            if [[ -n "$SUBNET_ERRORS" ]]; then
-                HAS_ISSUES=1
-                print_error "  Subnet configuration issues"
-                if ! echo "$SUBNET_ERRORS" | head -n 2 2>/dev/null | sed 's/^/    /' 2>/dev/null; then
-                    print_warning "    [Event details could not be displayed]"
-                fi
-            fi
+        SUBNET_ERRORS_HUMAN=$(echo "$ERROR_EVENTS" | jq -r '.[] | select(.message | test("subnet|availability zone"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
+        if [[ -n "$SUBNET_ERRORS_HUMAN" ]]; then
+            mark_affected "$INGRESS_NAME"
+            INGRESS_HAS_ISSUE=1
+            print_error "  Subnet configuration issues"
+            echo "$SUBNET_ERRORS_HUMAN" | head -n 2 | sed 's/^/    /'
+            SUBNET_ERROR_LINES=$(echo "$ERROR_EVENTS" | jq -c '[.[] | select(.message | test("subnet|availability zone"; "i")) | {timestamp: .lastTimestamp, type: .type, reason: .reason, message: .message}] | .[:2]')
+            ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson events "$SUBNET_ERROR_LINES" \
+                '{ingress: $ing, issue: "subnet_misconfiguration", events: $events}')
+            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+        fi
 
-            # Check for security group errors
-            SG_ERRORS=$(echo "$ERROR_EVENTS" | jq -r 'select(.message | test("security.?group"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
-            if [[ -n "$SG_ERRORS" ]]; then
-                HAS_ISSUES=1
-                print_error "  Security group issues"
-                if ! echo "$SG_ERRORS" | head -n 2 2>/dev/null | sed 's/^/    /' 2>/dev/null; then
-                    print_warning "    [Event details could not be displayed]"
-                fi
-            fi
+        SG_ERRORS_HUMAN=$(echo "$ERROR_EVENTS" | jq -r '.[] | select(.message | test("security.?group"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
+        if [[ -n "$SG_ERRORS_HUMAN" ]]; then
+            mark_affected "$INGRESS_NAME"
+            INGRESS_HAS_ISSUE=1
+            print_error "  Security group issues"
+            echo "$SG_ERRORS_HUMAN" | head -n 2 | sed 's/^/    /'
+            SG_ERROR_LINES=$(echo "$ERROR_EVENTS" | jq -c '[.[] | select(.message | test("security.?group"; "i")) | {timestamp: .lastTimestamp, type: .type, reason: .reason, message: .message}] | .[:2]')
+            ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson events "$SG_ERROR_LINES" \
+                '{ingress: $ing, issue: "security_group", events: $events}')
+            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+        fi
 
-            # Check for target group errors
-            TG_ERRORS=$(echo "$ERROR_EVENTS" | jq -r 'select(.message | test("target.?group"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
-            if [[ -n "$TG_ERRORS" ]]; then
-                HAS_ISSUES=1
-                print_error "  Target group registration issues"
-                if ! echo "$TG_ERRORS" | head -n 2 2>/dev/null | sed 's/^/    /' 2>/dev/null; then
-                    print_warning "    [Event details could not be displayed]"
-                fi
-            fi
+        TG_ERRORS_HUMAN=$(echo "$ERROR_EVENTS" | jq -r '.[] | select(.message | test("target.?group"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
+        if [[ -n "$TG_ERRORS_HUMAN" ]]; then
+            mark_affected "$INGRESS_NAME"
+            INGRESS_HAS_ISSUE=1
+            print_error "  Target group registration issues"
+            echo "$TG_ERRORS_HUMAN" | head -n 2 | sed 's/^/    /'
+            TG_ERROR_LINES=$(echo "$ERROR_EVENTS" | jq -c '[.[] | select(.message | test("target.?group"; "i")) | {timestamp: .lastTimestamp, type: .type, reason: .reason, message: .message}] | .[:2]')
+            ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson events "$TG_ERROR_LINES" \
+                '{ingress: $ing, issue: "target_group", events: $events}')
+            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
         fi
     fi
 
-    # ===== Annotation Checks (scheme, subnets) =====
-    SCHEME=$(echo "$INGRESS_INFO" | jq -r '.metadata.annotations["alb.ingress.kubernetes.io/scheme"] // empty')
     if [[ -z "$SCHEME" ]]; then
         print_warning "  No scheme annotation (defaulting to internal)"
         print_info "    Add annotation: alb.ingress.kubernetes.io/scheme=internet-facing (or internal)"
     fi
-
-    SUBNETS=$(echo "$INGRESS_INFO" | jq -r '.metadata.annotations["alb.ingress.kubernetes.io/subnets"] // empty')
     if [[ -z "$SUBNETS" ]]; then
         print_info "  Using auto-discovered subnets"
         print_info "    Consider explicit subnets: alb.ingress.kubernetes.io/subnets=<subnet-ids>"
     fi
+
+    INGRESS_FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg cert "$CERT_ARN" --arg scheme "$SCHEME" --arg subnets "$SUBNETS" \
+        --argjson tls_configured "$([[ -n "$TLS_HOSTS" || -n "$CERT_ARN" ]] && echo true || echo false)" \
+        --argjson host_mismatches "$HOST_TLS_MISMATCHES" \
+        --argjson cert_errors "$CERT_ERROR_LINES" \
+        --argjson subnet_errors "$SUBNET_ERROR_LINES" \
+        --argjson sg_errors "$SG_ERROR_LINES" \
+        --argjson tg_errors "$TG_ERROR_LINES" \
+        '{
+            ingress: $ing,
+            tls_configured: $tls_configured,
+            certificate_arn: (if $cert == "" then null else $cert end),
+            scheme: (if $scheme == "" then null else $scheme end),
+            subnets_annotation: (if $subnets == "" then null else $subnets end),
+            host_tls_mismatches: $host_mismatches,
+            certificate_errors: $cert_errors,
+            subnet_errors: $subnet_errors,
+            security_group_errors: $sg_errors,
+            target_group_errors: $tg_errors
+        }')
+    INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$INGRESS_FACT" '. + [$i]')
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
+INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "No critical ALB capacity or configuration issues detected"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "No critical ALB capacity or configuration issues detected" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$INGRESS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) affected by ALB issues"
+    [[ $HAS_IP_EXHAUSTION -eq 1 ]] && SUMMARY="$SUMMARY — subnet IP exhaustion detected"
+
+    DETAILS=$(jq -nc \
+        --argjson facts "$INGRESS_FACTS" \
+        --argjson issues "$ISSUE_FACTS" \
+        --argjson count "$INGRESS_COUNT" \
+        --argjson ip_logs "$IP_EXHAUSTION_LOGS" \
+        --argjson ip_exhaustion "$HAS_IP_EXHAUSTION" \
+        '{
+            ingress_count: $count,
+            issue_count: ($issues | length),
+            ip_exhaustion_detected: ($ip_exhaustion == 1),
+            ip_exhaustion_logs: $ip_logs,
+            ingresses: $facts,
+            issues: $issues
+        }')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+        '["Check subnet capacity and certificate/security group configuration"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/alb_capacity_check
+++ b/k8s/diagnose/networking/alb_capacity_check
@@ -6,15 +6,12 @@ require_ingresses || return 0
 
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-ISSUE_FACTS="[]"
-INGRESS_FACTS="[]"
-AFFECTED_INGRESSES="[]"
+ISSUE_FACTS=()
+INGRESS_FACTS=()
+AFFECTED_INGRESSES=""
 HAS_IP_EXHAUSTION=0
 IP_EXHAUSTION_LOGS="[]"
 
-mark_affected() {
-    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
-}
 
 ALB_CONTROLLER_PODS=$(jq -r '.items[].metadata.name' "$ALB_CONTROLLER_PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
@@ -53,9 +50,9 @@ fi
 [[ $HAS_IP_EXHAUSTION -eq 1 ]] && {
     ISSUE=$(jq -nc --argjson logs "$IP_EXHAUSTION_LOGS" \
         '{issue: "subnet_ip_exhaustion", evidence_logs: $logs}')
-    ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+    add_fact ISSUE_FACTS "$ISSUE"
     # mark all ingresses as affected (cluster-wide issue)
-    for INGRESS_NAME in $INGRESSES; do mark_affected "$INGRESS_NAME"; done
+    for INGRESS_NAME in $INGRESSES; do mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"; done
 }
 
 for INGRESS_NAME in $INGRESSES; do
@@ -88,7 +85,7 @@ for INGRESS_NAME in $INGRESSES; do
                             grep -iE "certificate.*(not found|invalid|failed|error)" 2>/dev/null || true)
 
                         if [[ -n "$CERT_ERRORS" ]]; then
-                            mark_affected "$INGRESS_NAME"
+                            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                             INGRESS_HAS_ISSUE=1
                             print_error "    Certificate validation errors found:"
                             if ! echo "$CERT_ERRORS" | tail -n 2 2>/dev/null | cut -c1-200 2>/dev/null | sed 's/^/      /' 2>/dev/null; then
@@ -101,7 +98,7 @@ for INGRESS_NAME in $INGRESSES; do
                                 '. + [{controller_pod: $pod, lines: $lines}]')
                             ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson lines "$TRUNC" \
                                 '{ingress: $ing, issue: "certificate_validation_errors", log_lines: $lines}')
-                            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                            add_fact ISSUE_FACTS "$ISSUE"
                         fi
                     fi
                 done
@@ -111,14 +108,14 @@ for INGRESS_NAME in $INGRESSES; do
         if [[ -n "$TLS_HOSTS" && -n "$INGRESS_HOSTS" ]]; then
             for HOST in $INGRESS_HOSTS; do
                 if ! echo "$TLS_HOSTS" | grep -qw "$HOST"; then
-                    mark_affected "$INGRESS_NAME"
+                    mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                     INGRESS_HAS_ISSUE=1
                     print_error "    Host '$HOST' in rules but not in TLS configuration"
                     print_action "Add host to spec.tls or ensure certificate covers this domain"
                     HOST_TLS_MISMATCHES=$(echo "$HOST_TLS_MISMATCHES" | jq --arg h "$HOST" '. + [$h]')
                     ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg host "$HOST" \
                         '{ingress: $ing, host: $host, issue: "host_in_rules_not_in_tls"}')
-                    ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                    add_fact ISSUE_FACTS "$ISSUE"
                 fi
             done
         fi
@@ -149,38 +146,38 @@ for INGRESS_NAME in $INGRESSES; do
 
         SUBNET_ERRORS_HUMAN=$(echo "$ERROR_EVENTS" | jq -r '.[] | select(.message | test("subnet|availability zone"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
         if [[ -n "$SUBNET_ERRORS_HUMAN" ]]; then
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             INGRESS_HAS_ISSUE=1
             print_error "  Subnet configuration issues"
             echo "$SUBNET_ERRORS_HUMAN" | head -n 2 | sed 's/^/    /'
             SUBNET_ERROR_LINES=$(echo "$ERROR_EVENTS" | jq -c '[.[] | select(.message | test("subnet|availability zone"; "i")) | {timestamp: .lastTimestamp, type: .type, reason: .reason, message: .message}] | .[:2]')
             ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson events "$SUBNET_ERROR_LINES" \
                 '{ingress: $ing, issue: "subnet_misconfiguration", events: $events}')
-            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+            add_fact ISSUE_FACTS "$ISSUE"
         fi
 
         SG_ERRORS_HUMAN=$(echo "$ERROR_EVENTS" | jq -r '.[] | select(.message | test("security.?group"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
         if [[ -n "$SG_ERRORS_HUMAN" ]]; then
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             INGRESS_HAS_ISSUE=1
             print_error "  Security group issues"
             echo "$SG_ERRORS_HUMAN" | head -n 2 | sed 's/^/    /'
             SG_ERROR_LINES=$(echo "$ERROR_EVENTS" | jq -c '[.[] | select(.message | test("security.?group"; "i")) | {timestamp: .lastTimestamp, type: .type, reason: .reason, message: .message}] | .[:2]')
             ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson events "$SG_ERROR_LINES" \
                 '{ingress: $ing, issue: "security_group", events: $events}')
-            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+            add_fact ISSUE_FACTS "$ISSUE"
         fi
 
         TG_ERRORS_HUMAN=$(echo "$ERROR_EVENTS" | jq -r '.[] | select(.message | test("target.?group"; "i")) | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"' 2>/dev/null || true)
         if [[ -n "$TG_ERRORS_HUMAN" ]]; then
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             INGRESS_HAS_ISSUE=1
             print_error "  Target group registration issues"
             echo "$TG_ERRORS_HUMAN" | head -n 2 | sed 's/^/    /'
             TG_ERROR_LINES=$(echo "$ERROR_EVENTS" | jq -c '[.[] | select(.message | test("target.?group"; "i")) | {timestamp: .lastTimestamp, type: .type, reason: .reason, message: .message}] | .[:2]')
             ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson events "$TG_ERROR_LINES" \
                 '{ingress: $ing, issue: "target_group", events: $events}')
-            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+            add_fact ISSUE_FACTS "$ISSUE"
         fi
     fi
 
@@ -212,11 +209,11 @@ for INGRESS_NAME in $INGRESSES; do
             security_group_errors: $sg_errors,
             target_group_errors: $tg_errors
         }')
-    INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$INGRESS_FACT" '. + [$i]')
+    add_fact INGRESS_FACTS "$INGRESS_FACT"
 done
 
 INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "No critical ALB capacity or configuration issues detected"
@@ -224,7 +221,7 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "No critical ALB capacity or configuration issues detected" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$INGRESS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array INGRESS_FACTS)" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
@@ -232,8 +229,8 @@ else
     [[ $HAS_IP_EXHAUSTION -eq 1 ]] && SUMMARY="$SUMMARY — subnet IP exhaustion detected"
 
     DETAILS=$(jq -nc \
-        --argjson facts "$INGRESS_FACTS" \
-        --argjson issues "$ISSUE_FACTS" \
+        --argjson facts "$(facts_to_json_array INGRESS_FACTS)" \
+        --argjson issues "$(facts_to_json_array ISSUE_FACTS)" \
         --argjson count "$INGRESS_COUNT" \
         --argjson ip_logs "$IP_EXHAUSTION_LOGS" \
         --argjson ip_exhaustion "$HAS_IP_EXHAUSTION" \
@@ -245,7 +242,7 @@ else
             ingresses: $facts,
             issues: $issues
         }')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_INGRESSES)" "$DETAILS" \
         '["Check subnet capacity and certificate/security group configuration"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_backend_service
+++ b/k8s/diagnose/networking/ingress_backend_service
@@ -2,99 +2,111 @@
 # Check: Ingress Backend Service
 # Checks if ingress backend services exist and are reachable
 
-# Validate ingresses exist
 require_ingresses || return 0
 
-# Get ingresses
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+ISSUE_FACTS="[]"
+INGRESS_FACTS="[]"
+AFFECTED_INGRESSES="[]"
+
+mark_affected() {
+    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
+}
 
 for INGRESS_NAME in $INGRESSES; do
     INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
-
     print_info "Checking backends for ingress: $INGRESS_NAME"
 
-    # Get default backend if exists
+    INGRESS_BACKEND_FACTS="[]"
+    INGRESS_HAS_ISSUE=0
+
     DEFAULT_BACKEND=$(echo "$INGRESS_INFO" | jq -r '.spec.defaultBackend.service.name // empty')
 
     if [[ -n "$DEFAULT_BACKEND" ]]; then
         DEFAULT_PORT=$(echo "$INGRESS_INFO" | jq -r '.spec.defaultBackend.service.port.number // .spec.defaultBackend.service.port.name // empty')
-
-        # Check if service exists in pre-collected data
         SERVICE_INFO=$(jq --arg name "$DEFAULT_BACKEND" '.items[] | select(.metadata.name == $name)' "$SERVICES_FILE" 2>/dev/null)
 
         if [[ -n "$SERVICE_INFO" && "$SERVICE_INFO" != "null" ]]; then
-            # Check if service has endpoints from pre-collected data
             ENDPOINT_INFO=$(jq --arg name "$DEFAULT_BACKEND" '.items[] | select(.metadata.name == $name)' "$ENDPOINTS_FILE" 2>/dev/null)
             ENDPOINTS=$(echo "$ENDPOINT_INFO" | jq -r '.subsets[].addresses[].ip' 2>/dev/null | tr '\n' ' ')
 
             if [[ -n "$ENDPOINTS" ]]; then
                 print_success "  Default backend: $DEFAULT_BACKEND:$DEFAULT_PORT (has endpoints)"
+                BFACT=$(jq -nc --arg svc "$DEFAULT_BACKEND" --arg port "$DEFAULT_PORT" \
+                    '{kind: "default", service: $svc, port: $port, status: "ok"}')
             else
-                HAS_ISSUES=1
+                mark_affected "$INGRESS_NAME"
+                INGRESS_HAS_ISSUE=1
                 print_error "  Default backend: $DEFAULT_BACKEND:$DEFAULT_PORT (no endpoints)"
+                BFACT=$(jq -nc --arg svc "$DEFAULT_BACKEND" --arg port "$DEFAULT_PORT" \
+                    '{kind: "default", service: $svc, port: $port, status: "no_endpoints"}')
+                ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$DEFAULT_BACKEND" \
+                    '{ingress: $ing, backend: $svc, issue: "default_backend_no_endpoints"}')
+                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
             fi
         else
-            HAS_ISSUES=1
+            mark_affected "$INGRESS_NAME"
+            INGRESS_HAS_ISSUE=1
             print_error "  Default backend: Service '$DEFAULT_BACKEND' not found"
+            BFACT=$(jq -nc --arg svc "$DEFAULT_BACKEND" \
+                '{kind: "default", service: $svc, status: "service_not_found"}')
+            ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$DEFAULT_BACKEND" \
+                '{ingress: $ing, backend: $svc, issue: "default_backend_not_found"}')
+            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
         fi
+        INGRESS_BACKEND_FACTS=$(echo "$INGRESS_BACKEND_FACTS" | jq --argjson b "$BFACT" '. + [$b]')
     fi
 
-    # Get all rule backends
     BACKENDS=$(echo "$INGRESS_INFO" | jq -r '.spec.rules[].http.paths[] | "\(.backend.service.name):\(.backend.service.port.number // .backend.service.port.name)"' 2>/dev/null)
 
-    if [[ -z "$BACKENDS" ]]; then
+    if [[ -z "$BACKENDS" && -z "$DEFAULT_BACKEND" ]]; then
         print_warning "  No path rules defined"
+        FACT=$(jq -nc --arg ing "$INGRESS_NAME" --argjson backends "$INGRESS_BACKEND_FACTS" \
+            '{ingress: $ing, backends: $backends}')
+        INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$FACT" '. + [$i]')
         continue
     fi
 
-    # Check each unique backend
-    # Use process substitution to avoid subshell and preserve HAS_ISSUES updates
     while IFS=':' read -r SERVICE_NAME SERVICE_PORT; do
-        # Check if service exists in pre-collected data
+        [[ -z "$SERVICE_NAME" ]] && continue
+
         SERVICE_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$SERVICES_FILE" 2>/dev/null)
 
         if [[ -n "$SERVICE_INFO" && "$SERVICE_INFO" != "null" ]]; then
-            # Check if service has endpoints from pre-collected data
             ENDPOINT_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$ENDPOINTS_FILE" 2>/dev/null)
-            READY_ENDPOINTS=$(echo "$ENDPOINT_INFO" | jq -r '.subsets[]?.addresses[]? | "\(.targetRef.name // "unknown"):\(.ip)"' 2>/dev/null)
-            NOT_READY_ENDPOINTS=$(echo "$ENDPOINT_INFO" | jq -r '.subsets[]?.notReadyAddresses[]? | "\(.targetRef.name // "unknown"):\(.ip)"' 2>/dev/null)
+            READY_COUNT=$(echo "$ENDPOINT_INFO" | jq -r '[.subsets[]?.addresses[]?] | length' 2>/dev/null)
+            NOT_READY_COUNT=$(echo "$ENDPOINT_INFO" | jq -r '[.subsets[]?.notReadyAddresses[]?] | length' 2>/dev/null)
+            READY_COUNT=${READY_COUNT:-0}
+            NOT_READY_COUNT=${NOT_READY_COUNT:-0}
 
-            # Get port info
             PORT_NUMBER=$(echo "$ENDPOINT_INFO" | jq -r '.subsets[0]?.ports[0]?.port // empty' 2>/dev/null)
-
-            READY_COUNT=$(echo "$READY_ENDPOINTS" | grep -c '^' 2>/dev/null || echo 0)
-            NOT_READY_COUNT=$(echo "$NOT_READY_ENDPOINTS" | grep -c '^' 2>/dev/null || echo 0)
 
             if [[ $READY_COUNT -gt 0 ]]; then
                 print_success "  Backend: $SERVICE_NAME:$SERVICE_PORT ($READY_COUNT ready endpoint(s))"
-                echo "$READY_ENDPOINTS" | while IFS=':' read -r POD_NAME IP; do
-                    [[ -n "$IP" ]] && print_success "    - $POD_NAME -> $IP:$PORT_NUMBER"
+                echo "$ENDPOINT_INFO" | jq -r --arg p "$PORT_NUMBER" '.subsets[]?.addresses[]? | "    - \(.targetRef.name // "unknown") -> \(.ip)" + (if $p == "" then "" else ":" + $p end)' | while IFS= read -r line; do
+                    print_success "$line"
                 done
-
                 if [[ $NOT_READY_COUNT -gt 0 ]]; then
                     print_warning "    Also has $NOT_READY_COUNT not ready endpoint(s)"
-                    echo "$NOT_READY_ENDPOINTS" | while IFS=':' read -r POD_NAME IP; do
-                        [[ -n "$IP" ]] && print_warning "      - $POD_NAME -> $IP:$PORT_NUMBER"
+                    echo "$ENDPOINT_INFO" | jq -r --arg p "$PORT_NUMBER" '.subsets[]?.notReadyAddresses[]? | "      - \(.targetRef.name // "unknown") -> \(.ip)" + (if $p == "" then "" else ":" + $p end)' | while IFS= read -r line; do
+                        print_warning "$line"
                     done
                 fi
+                BFACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg port "$SERVICE_PORT" --argjson ready "$READY_COUNT" --argjson nr "$NOT_READY_COUNT" \
+                    '{kind: "rule", service: $svc, port: $port, ready_count: $ready, not_ready_count: $nr, status: "ok"}')
             else
-                HAS_ISSUES=1
+                mark_affected "$INGRESS_NAME"
+                INGRESS_HAS_ISSUE=1
                 print_error "  Backend: $SERVICE_NAME:$SERVICE_PORT (no ready endpoints)"
 
-                # Get service selector to help debug
                 SERVICE_SELECTOR=$(echo "$SERVICE_INFO" | jq -c '.spec.selector // {}' 2>/dev/null)
-                print_info "    Service selector: $SERVICE_SELECTOR"
 
                 if [[ $NOT_READY_COUNT -gt 0 ]]; then
-                    print_warning "    Found $NOT_READY_COUNT not ready endpoint(s):"
-                    echo "$NOT_READY_ENDPOINTS" | while IFS=':' read -r POD_NAME IP; do
-                        [[ -n "$IP" ]] && print_warning "      - $POD_NAME -> $IP:$PORT_NUMBER (not ready)"
-                    done
+                    print_warning "    Found $NOT_READY_COUNT not ready endpoint(s)"
                     print_action "Check pod readiness - pods exist but are not ready to serve traffic"
+                    SUB_ISSUE="endpoints_not_ready"
                 else
-                    # Check if there are any pods matching the selector
                     if [[ "$SERVICE_SELECTOR" != "{}" && "$SERVICE_SELECTOR" != "null" ]]; then
                         MATCHING_PODS=$(jq -r --argjson selectors "$SERVICE_SELECTOR" '
                             .items[] |
@@ -108,38 +120,77 @@ for INGRESS_NAME in $INGRESSES; do
                         ' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
                         if [[ -n "$MATCHING_PODS" ]]; then
-                            print_warning "    Found pods matching selector but no endpoints: $MATCHING_PODS"
-                            print_action "Pods exist but endpoints not created - check pod readiness probes and status"
+                            print_warning "    Pods match selector but no endpoints — check readiness probes"
+                            SUB_ISSUE="pods_match_no_endpoints"
                         else
                             print_warning "    No pods found matching service selector"
-                            print_action "Create pods with labels matching the service selector: $SERVICE_SELECTOR"
+                            SUB_ISSUE="no_matching_pods"
                         fi
                     else
                         print_warning "    Service has no selector defined"
-                        print_action "Add selector to service or check if this is a headless/ExternalName service"
+                        SUB_ISSUE="no_selector"
                     fi
                 fi
+
+                BFACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg port "$SERVICE_PORT" --argjson nr "$NOT_READY_COUNT" \
+                    --argjson selector "$SERVICE_SELECTOR" --arg issue "$SUB_ISSUE" \
+                    '{kind: "rule", service: $svc, port: $port, ready_count: 0, not_ready_count: $nr, selector: $selector, status: $issue}')
+                ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$SERVICE_NAME" --arg issue "$SUB_ISSUE" \
+                    '{ingress: $ing, backend: $svc, issue: $issue}')
+                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
             fi
 
-            # Verify port exists in service from pre-collected data
             SERVICE_PORTS=$(echo "$SERVICE_INFO" | jq -r '.spec.ports[].port' 2>/dev/null | tr '\n' ' ')
-
             if ! echo "$SERVICE_PORTS" | grep -qw "$SERVICE_PORT"; then
-                HAS_ISSUES=1
+                mark_affected "$INGRESS_NAME"
+                INGRESS_HAS_ISSUE=1
                 print_error "  Backend: Port $SERVICE_PORT not found in service $SERVICE_NAME"
                 print_warning "    Available ports: $SERVICE_PORTS"
+                BFACT=$(echo "$BFACT" | jq --arg sp "$SERVICE_PORT" --arg ports "$SERVICE_PORTS" \
+                    '. + {port_status: "port_not_in_service", available_ports: ($ports | split(" ") | map(select(length > 0)))}')
+                ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$SERVICE_NAME" --arg port "$SERVICE_PORT" \
+                    '{ingress: $ing, backend: $svc, port: $port, issue: "port_not_in_service"}')
+                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
             fi
         else
-            HAS_ISSUES=1
+            mark_affected "$INGRESS_NAME"
+            INGRESS_HAS_ISSUE=1
             print_error "  Backend: Service '$SERVICE_NAME' not found in namespace"
+            BFACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg port "$SERVICE_PORT" \
+                '{kind: "rule", service: $svc, port: $port, status: "service_not_found"}')
+            ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$SERVICE_NAME" \
+                '{ingress: $ing, backend: $svc, issue: "service_not_found"}')
+            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
         fi
+
+        INGRESS_BACKEND_FACTS=$(echo "$INGRESS_BACKEND_FACTS" | jq --argjson b "$BFACT" '. + [$b]')
     done < <(echo "$BACKENDS" | sort -u)
+
+    FACT=$(jq -nc --arg ing "$INGRESS_NAME" --argjson backends "$INGRESS_BACKEND_FACTS" \
+        '{ingress: $ing, backends: $backends}')
+    INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$FACT" '. + [$i]')
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
-    INGRESS_COUNT=$(echo "$INGRESSES" | wc -w)
+INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "All backend services healthy for $INGRESS_COUNT ingress(es)"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "All backend services healthy for $INGRESS_COUNT ingress(es)" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$INGRESS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have backend issues"
+    DETAILS=$(jq -nc \
+        --argjson facts "$INGRESS_FACTS" \
+        --argjson issues "$ISSUE_FACTS" \
+        --argjson count "$INGRESS_COUNT" \
+        '{ingress_count: $count, issue_count: ($issues | length), ingresses: $facts, issues: $issues}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+        '["Verify backend services exist and have ready endpoints, and that ports match"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_backend_service
+++ b/k8s/diagnose/networking/ingress_backend_service
@@ -6,19 +6,16 @@ require_ingresses || return 0
 
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-ISSUE_FACTS="[]"
-INGRESS_FACTS="[]"
-AFFECTED_INGRESSES="[]"
+ISSUE_FACTS=()
+INGRESS_FACTS=()
+AFFECTED_INGRESSES=""
 
-mark_affected() {
-    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
-}
 
 for INGRESS_NAME in $INGRESSES; do
     INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
     print_info "Checking backends for ingress: $INGRESS_NAME"
 
-    INGRESS_BACKEND_FACTS="[]"
+    INGRESS_BACKEND_FACTS=()
     INGRESS_HAS_ISSUE=0
 
     DEFAULT_BACKEND=$(echo "$INGRESS_INFO" | jq -r '.spec.defaultBackend.service.name // empty')
@@ -36,26 +33,26 @@ for INGRESS_NAME in $INGRESSES; do
                 BFACT=$(jq -nc --arg svc "$DEFAULT_BACKEND" --arg port "$DEFAULT_PORT" \
                     '{kind: "default", service: $svc, port: $port, status: "ok"}')
             else
-                mark_affected "$INGRESS_NAME"
+                mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                 INGRESS_HAS_ISSUE=1
                 print_error "  Default backend: $DEFAULT_BACKEND:$DEFAULT_PORT (no endpoints)"
                 BFACT=$(jq -nc --arg svc "$DEFAULT_BACKEND" --arg port "$DEFAULT_PORT" \
                     '{kind: "default", service: $svc, port: $port, status: "no_endpoints"}')
                 ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$DEFAULT_BACKEND" \
                     '{ingress: $ing, backend: $svc, issue: "default_backend_no_endpoints"}')
-                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                add_fact ISSUE_FACTS "$ISSUE"
             fi
         else
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             INGRESS_HAS_ISSUE=1
             print_error "  Default backend: Service '$DEFAULT_BACKEND' not found"
             BFACT=$(jq -nc --arg svc "$DEFAULT_BACKEND" \
                 '{kind: "default", service: $svc, status: "service_not_found"}')
             ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$DEFAULT_BACKEND" \
                 '{ingress: $ing, backend: $svc, issue: "default_backend_not_found"}')
-            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+            add_fact ISSUE_FACTS "$ISSUE"
         fi
-        INGRESS_BACKEND_FACTS=$(echo "$INGRESS_BACKEND_FACTS" | jq --argjson b "$BFACT" '. + [$b]')
+        add_fact INGRESS_BACKEND_FACTS "$BFACT"
     fi
 
     BACKENDS=$(echo "$INGRESS_INFO" | jq -r '.spec.rules[].http.paths[] | "\(.backend.service.name):\(.backend.service.port.number // .backend.service.port.name)"' 2>/dev/null)
@@ -64,7 +61,7 @@ for INGRESS_NAME in $INGRESSES; do
         print_warning "  No path rules defined"
         FACT=$(jq -nc --arg ing "$INGRESS_NAME" --argjson backends "$INGRESS_BACKEND_FACTS" \
             '{ingress: $ing, backends: $backends}')
-        INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$FACT" '. + [$i]')
+        add_fact INGRESS_FACTS "$FACT"
         continue
     fi
 
@@ -96,7 +93,7 @@ for INGRESS_NAME in $INGRESSES; do
                 BFACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg port "$SERVICE_PORT" --argjson ready "$READY_COUNT" --argjson nr "$NOT_READY_COUNT" \
                     '{kind: "rule", service: $svc, port: $port, ready_count: $ready, not_ready_count: $nr, status: "ok"}')
             else
-                mark_affected "$INGRESS_NAME"
+                mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                 INGRESS_HAS_ISSUE=1
                 print_error "  Backend: $SERVICE_NAME:$SERVICE_PORT (no ready endpoints)"
 
@@ -137,12 +134,12 @@ for INGRESS_NAME in $INGRESSES; do
                     '{kind: "rule", service: $svc, port: $port, ready_count: 0, not_ready_count: $nr, selector: $selector, status: $issue}')
                 ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$SERVICE_NAME" --arg issue "$SUB_ISSUE" \
                     '{ingress: $ing, backend: $svc, issue: $issue}')
-                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                add_fact ISSUE_FACTS "$ISSUE"
             fi
 
             SERVICE_PORTS=$(echo "$SERVICE_INFO" | jq -r '.spec.ports[].port' 2>/dev/null | tr '\n' ' ')
             if ! echo "$SERVICE_PORTS" | grep -qw "$SERVICE_PORT"; then
-                mark_affected "$INGRESS_NAME"
+                mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                 INGRESS_HAS_ISSUE=1
                 print_error "  Backend: Port $SERVICE_PORT not found in service $SERVICE_NAME"
                 print_warning "    Available ports: $SERVICE_PORTS"
@@ -150,29 +147,29 @@ for INGRESS_NAME in $INGRESSES; do
                     '. + {port_status: "port_not_in_service", available_ports: ($ports | split(" ") | map(select(length > 0)))}')
                 ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$SERVICE_NAME" --arg port "$SERVICE_PORT" \
                     '{ingress: $ing, backend: $svc, port: $port, issue: "port_not_in_service"}')
-                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                add_fact ISSUE_FACTS "$ISSUE"
             fi
         else
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             INGRESS_HAS_ISSUE=1
             print_error "  Backend: Service '$SERVICE_NAME' not found in namespace"
             BFACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg port "$SERVICE_PORT" \
                 '{kind: "rule", service: $svc, port: $port, status: "service_not_found"}')
             ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg svc "$SERVICE_NAME" \
                 '{ingress: $ing, backend: $svc, issue: "service_not_found"}')
-            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+            add_fact ISSUE_FACTS "$ISSUE"
         fi
 
-        INGRESS_BACKEND_FACTS=$(echo "$INGRESS_BACKEND_FACTS" | jq --argjson b "$BFACT" '. + [$b]')
+        add_fact INGRESS_BACKEND_FACTS "$BFACT"
     done < <(echo "$BACKENDS" | sort -u)
 
     FACT=$(jq -nc --arg ing "$INGRESS_NAME" --argjson backends "$INGRESS_BACKEND_FACTS" \
         '{ingress: $ing, backends: $backends}')
-    INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$FACT" '. + [$i]')
+    add_fact INGRESS_FACTS "$FACT"
 done
 
 INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "All backend services healthy for $INGRESS_COUNT ingress(es)"
@@ -180,17 +177,17 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "All backend services healthy for $INGRESS_COUNT ingress(es)" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$INGRESS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array INGRESS_FACTS)" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have backend issues"
     DETAILS=$(jq -nc \
-        --argjson facts "$INGRESS_FACTS" \
-        --argjson issues "$ISSUE_FACTS" \
+        --argjson facts "$(facts_to_json_array INGRESS_FACTS)" \
+        --argjson issues "$(facts_to_json_array ISSUE_FACTS)" \
         --argjson count "$INGRESS_COUNT" \
         '{ingress_count: $count, issue_count: ($issues | length), ingresses: $facts, issues: $issues}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_INGRESSES)" "$DETAILS" \
         '["Verify backend services exist and have ready endpoints, and that ports match"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_class_validation
+++ b/k8s/diagnose/networking/ingress_class_validation
@@ -6,12 +6,9 @@ require_ingresses || return 0
 
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-CLASS_FACTS="[]"
-AFFECTED_INGRESSES="[]"
+CLASS_FACTS=()
+AFFECTED_INGRESSES=""
 
-mark_affected() {
-    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
-}
 
 AVAILABLE_CLASSES=$(jq -r '.items[].metadata.name' "$INGRESSCLASSES_FILE" 2>/dev/null | tr '\n' ' ')
 AVAILABLE_CLASSES_JSON=$(jq -c '[.items[].metadata.name]' "$INGRESSCLASSES_FILE" 2>/dev/null)
@@ -37,7 +34,7 @@ for INGRESS_NAME in $INGRESSES; do
             FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg cls "$DEFAULT_CLASS" \
                 '{ingress: $ing, ingress_class: $cls, source: "default"}')
         else
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             print_error "Ingress $INGRESS_NAME: No IngressClass specified and no default found"
             print_action "Specify ingressClassName or set a default IngressClass"
             FACT=$(jq -nc --arg ing "$INGRESS_NAME" \
@@ -49,7 +46,7 @@ for INGRESS_NAME in $INGRESSES; do
             FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg cls "$INGRESS_CLASS" --argjson dep "$USED_DEPRECATED" \
                 '{ingress: $ing, ingress_class: $cls, used_deprecated_annotation: $dep, source: "explicit"}')
         else
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             print_error "Ingress $INGRESS_NAME: IngressClass '$INGRESS_CLASS' not found"
             if [[ -n "$AVAILABLE_CLASSES" ]]; then
                 print_warning "  Available classes: $AVAILABLE_CLASSES"
@@ -61,11 +58,11 @@ for INGRESS_NAME in $INGRESSES; do
                 '{ingress: $ing, ingress_class: $cls, issue: "ingress_class_not_found", available_classes: $available, used_deprecated_annotation: $dep}')
         fi
     fi
-    CLASS_FACTS=$(echo "$CLASS_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+    add_fact CLASS_FACTS "$FACT"
 done
 
 INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "All $INGRESS_COUNT ingress(es) have valid IngressClass configuration"
@@ -73,19 +70,19 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "All $INGRESS_COUNT ingress(es) have valid IngressClass configuration" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$CLASS_FACTS" --argjson count "$INGRESS_COUNT" --arg default "$DEFAULT_CLASS" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array CLASS_FACTS)" --argjson count "$INGRESS_COUNT" --arg default "$DEFAULT_CLASS" \
             '{ingress_count: $count, default_class: $default, ingresses: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have IngressClass issues"
     DETAILS=$(jq -nc \
-        --argjson facts "$CLASS_FACTS" \
+        --argjson facts "$(facts_to_json_array CLASS_FACTS)" \
         --argjson available "$AVAILABLE_CLASSES_JSON" \
         --arg default "$DEFAULT_CLASS" \
         --argjson count "$INGRESS_COUNT" \
         '{ingress_count: $count, available_classes: $available, default_class: $default, ingresses: $facts}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_INGRESSES)" "$DETAILS" \
         '["Specify ingressClassName or set a default IngressClass"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_class_validation
+++ b/k8s/diagnose/networking/ingress_class_validation
@@ -2,63 +2,90 @@
 # Check: Ingress Class Validation
 # Validates ingress class is correctly configured
 
-# Validate ingresses exist
 require_ingresses || return 0
 
-# Read ingresses from pre-collected data
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+CLASS_FACTS="[]"
+AFFECTED_INGRESSES="[]"
 
-# Get available ingress classes from pre-collected data
+mark_affected() {
+    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
+}
+
 AVAILABLE_CLASSES=$(jq -r '.items[].metadata.name' "$INGRESSCLASSES_FILE" 2>/dev/null | tr '\n' ' ')
+AVAILABLE_CLASSES_JSON=$(jq -c '[.items[].metadata.name]' "$INGRESSCLASSES_FILE" 2>/dev/null)
 DEFAULT_CLASS=$(jq -r '.items[] | select(.metadata.annotations."ingressclass.kubernetes.io/is-default-class" == "true") | .metadata.name' "$INGRESSCLASSES_FILE" 2>/dev/null)
 
 for INGRESS_NAME in $INGRESSES; do
-    # Get ingress info from pre-collected data
     INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
 
-    # Check spec.ingressClassName (new way)
     INGRESS_CLASS=$(echo "$INGRESS_INFO" | jq -r '.spec.ingressClassName // empty')
+    USED_DEPRECATED=false
 
-    # Check annotation (old way)
     if [[ -z "$INGRESS_CLASS" ]]; then
         INGRESS_CLASS=$(echo "$INGRESS_INFO" | jq -r '.metadata.annotations["kubernetes.io/ingress.class"] // empty')
-
         if [[ -n "$INGRESS_CLASS" ]]; then
             print_info "Ingress $INGRESS_NAME: Using deprecated annotation (kubernetes.io/ingress.class)"
+            USED_DEPRECATED=true
         fi
     fi
 
     if [[ -z "$INGRESS_CLASS" ]]; then
         if [[ -n "$DEFAULT_CLASS" ]]; then
             print_success "Ingress $INGRESS_NAME: Using default IngressClass ($DEFAULT_CLASS)"
+            FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg cls "$DEFAULT_CLASS" \
+                '{ingress: $ing, ingress_class: $cls, source: "default"}')
         else
-            HAS_ISSUES=1
+            mark_affected "$INGRESS_NAME"
             print_error "Ingress $INGRESS_NAME: No IngressClass specified and no default found"
             print_action "Specify ingressClassName or set a default IngressClass"
+            FACT=$(jq -nc --arg ing "$INGRESS_NAME" \
+                '{ingress: $ing, issue: "no_ingress_class_no_default"}')
         fi
     else
-        # Verify the class exists
         if echo "$AVAILABLE_CLASSES" | grep -qw "$INGRESS_CLASS"; then
             print_success "Ingress $INGRESS_NAME: IngressClass '$INGRESS_CLASS' is valid"
+            FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg cls "$INGRESS_CLASS" --argjson dep "$USED_DEPRECATED" \
+                '{ingress: $ing, ingress_class: $cls, used_deprecated_annotation: $dep, source: "explicit"}')
         else
-            HAS_ISSUES=1
+            mark_affected "$INGRESS_NAME"
             print_error "Ingress $INGRESS_NAME: IngressClass '$INGRESS_CLASS' not found"
-
             if [[ -n "$AVAILABLE_CLASSES" ]]; then
                 print_warning "  Available classes: $AVAILABLE_CLASSES"
             else
                 print_warning "  No IngressClasses found in cluster"
             fi
+            FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg cls "$INGRESS_CLASS" \
+                --argjson available "$AVAILABLE_CLASSES_JSON" --argjson dep "$USED_DEPRECATED" \
+                '{ingress: $ing, ingress_class: $cls, issue: "ingress_class_not_found", available_classes: $available, used_deprecated_annotation: $dep}')
         fi
     fi
+    CLASS_FACTS=$(echo "$CLASS_FACTS" | jq --argjson f "$FACT" '. + [$f]')
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
-    INGRESS_COUNT=$(echo "$INGRESSES" | wc -w)
+INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "All $INGRESS_COUNT ingress(es) have valid IngressClass configuration"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "All $INGRESS_COUNT ingress(es) have valid IngressClass configuration" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$CLASS_FACTS" --argjson count "$INGRESS_COUNT" --arg default "$DEFAULT_CLASS" \
+            '{ingress_count: $count, default_class: $default, ingresses: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have IngressClass issues"
+    DETAILS=$(jq -nc \
+        --argjson facts "$CLASS_FACTS" \
+        --argjson available "$AVAILABLE_CLASSES_JSON" \
+        --arg default "$DEFAULT_CLASS" \
+        --argjson count "$INGRESS_COUNT" \
+        '{ingress_count: $count, available_classes: $available, default_class: $default, ingresses: $facts}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+        '["Specify ingressClassName or set a default IngressClass"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_controller_sync
+++ b/k8s/diagnose/networking/ingress_controller_sync
@@ -2,15 +2,18 @@
 # Check: Ingress Controller Sync
 # Verifies ALB ingress controller has synchronized successfully
 
-# Validate ingresses exist
 require_ingresses || return 0
 
-# Read ingresses from pre-collected data
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+ISSUE_FACTS="[]"
+INGRESS_FACTS="[]"
+AFFECTED_INGRESSES="[]"
 
-# Get ALB controller pods from pre-collected data
+mark_affected() {
+    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
+}
+
 ALB_CONTROLLER_PODS=$(jq -r '.items[].metadata.name' "$ALB_CONTROLLER_PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
 if [[ -z "$ALB_CONTROLLER_PODS" ]]; then
@@ -23,7 +26,6 @@ fi
 for INGRESS_NAME in $INGRESSES; do
     print_info "Checking sync status for ingress: $INGRESS_NAME"
 
-    # Get ingress events from pre-collected data - sorted by timestamp, most recent first
     INGRESS_EVENTS_JSON=$(jq --arg name "$INGRESS_NAME" --arg kind "Ingress" '
         .items
         | map(select(.involvedObject.name == $name and .involvedObject.kind == $kind))
@@ -32,47 +34,62 @@ for INGRESS_NAME in $INGRESSES; do
     ' "$EVENTS_FILE" 2>/dev/null)
 
     EVENT_COUNT=$(echo "$INGRESS_EVENTS_JSON" | jq 'length' 2>/dev/null)
+    EVENT_SUMMARY="null"
+    INGRESS_HAS_ISSUE=0
+    DETECTED_PROBLEMS="[]"
+    LATEST_ERROR_EVENTS="[]"
 
     if [[ "$EVENT_COUNT" -gt 0 ]]; then
-        # Get the most recent event
         NEWEST_EVENT=$(echo "$INGRESS_EVENTS_JSON" | jq -r 'first')
         EVENT_TYPE=$(echo "$NEWEST_EVENT" | jq -r '.type')
         EVENT_REASON=$(echo "$NEWEST_EVENT" | jq -r '.reason')
         EVENT_MESSAGE=$(echo "$NEWEST_EVENT" | jq -r '.message')
         EVENT_TIMESTAMP=$(echo "$NEWEST_EVENT" | jq -r '.lastTimestamp')
 
-        # Check for successful reconciliation first
+        EVENT_SUMMARY=$(jq -nc --arg t "$EVENT_TYPE" --arg r "$EVENT_REASON" --arg m "$EVENT_MESSAGE" --arg ts "$EVENT_TIMESTAMP" \
+            '{type: $t, reason: $r, message: $m, last_timestamp: $ts}')
+
         if [[ "$EVENT_REASON" == "SuccessfullyReconciled" ]]; then
             print_success "  ✓ Successfully reconciled at $EVENT_TIMESTAMP"
         elif [[ "$EVENT_TYPE" == "Normal" ]] && echo "$EVENT_REASON" | grep -qiE "ensured|synced"; then
             print_success "  ✓ Last event: $EVENT_REASON at $EVENT_TIMESTAMP"
         else
-            # Look for error/warning events in recent history
             ERROR_EVENTS=$(echo "$INGRESS_EVENTS_JSON" | jq -r '
                 .[]
                 | select(.type == "Warning" or .type == "Error")
                 | "\(.lastTimestamp) [\(.type)] \(.reason): \(.message)"
             ' | head -n 5)
+            LATEST_ERROR_EVENTS=$(echo "$INGRESS_EVENTS_JSON" | jq -c '
+                [.[]
+                | select(.type == "Warning" or .type == "Error")
+                | {timestamp: .lastTimestamp, type: .type, reason: .reason, message: .message}]
+                | .[:5]
+            ')
 
             if [[ -n "$ERROR_EVENTS" ]]; then
-                HAS_ISSUES=1
+                mark_affected "$INGRESS_NAME"
+                INGRESS_HAS_ISSUE=1
                 print_error "  Found error/warning events:"
                 echo "$ERROR_EVENTS" | sed 's/^/    /'
 
-                # Check for specific ALB errors in all error events
                 ALL_ERROR_MESSAGES=$(echo "$INGRESS_EVENTS_JSON" | jq -r '.[] | select(.type == "Warning" or .type == "Error") | .message' 2>/dev/null)
 
                 if echo "$ALL_ERROR_MESSAGES" | grep -qi "failed to reconcile"; then
                     print_error "  Issue: Failed to reconcile ingress"
+                    DETECTED_PROBLEMS=$(echo "$DETECTED_PROBLEMS" | jq '. + ["failed_to_reconcile"]')
                 fi
-
                 if echo "$ALL_ERROR_MESSAGES" | grep -qi "no available ip\|insufficient.*address"; then
                     print_error "  Issue: No available IPs in subnet (see alb_capacity_check)"
+                    DETECTED_PROBLEMS=$(echo "$DETECTED_PROBLEMS" | jq '. + ["subnet_ip_exhaustion"]')
                 fi
-
                 if echo "$ALL_ERROR_MESSAGES" | grep -qi "certificate\|tls.*secret"; then
                     print_error "  Issue: Certificate problem detected (see ingress_tls_configuration)"
+                    DETECTED_PROBLEMS=$(echo "$DETECTED_PROBLEMS" | jq '. + ["certificate_issue"]')
                 fi
+
+                ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson problems "$DETECTED_PROBLEMS" --argjson events "$LATEST_ERROR_EVENTS" \
+                    '{ingress: $ing, issue: "sync_errors", detected_problems: $problems, recent_events: $events}')
+                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
             else
                 print_info "  Last event: $EVENT_REASON at $EVENT_TIMESTAMP"
             fi
@@ -81,32 +98,37 @@ for INGRESS_NAME in $INGRESSES; do
         print_warning "  No events found for this ingress"
     fi
 
-    # Check ALB controller logs if pods are found
+    CONTROLLER_LOG_ERRORS="[]"
     if [[ -n "$ALB_CONTROLLER_PODS" ]]; then
         for POD in $ALB_CONTROLLER_PODS; do
-            # Get recent logs related to this ingress from pre-collected logs
             LOG_FILE="$ALB_CONTROLLER_LOGS_DIR/${POD}.log"
             if [[ -f "$LOG_FILE" ]] && [[ -r "$LOG_FILE" ]]; then
-                # Use tail to limit log size and grep with line-buffered to avoid memory issues
-                # Skip lines longer than 10000 chars to avoid processing massive JSON lines
                 CONTROLLER_LOGS=$(tail -n 500 "$LOG_FILE" 2>/dev/null | \
                     awk 'length <= 10000' 2>/dev/null | \
                     grep -iF "$INGRESS_NAME" 2>/dev/null || true)
 
                 if [[ -n "$CONTROLLER_LOGS" ]]; then
-                    # Look for errors in controller logs (excluding "successfully built model" info logs)
                     ERROR_LOGS=$(echo "$CONTROLLER_LOGS" | \
                         grep -ivE "successfully built model|successfully reconciled" 2>/dev/null | \
                         grep -iE "level.*error|level.*warn|failed|warning" 2>/dev/null | \
                         head -n 5 || true)
 
                     if [[ -n "$ERROR_LOGS" ]]; then
-                        HAS_ISSUES=1
+                        mark_affected "$INGRESS_NAME"
+                        INGRESS_HAS_ISSUE=1
                         print_error "  Found errors in ALB controller logs:"
-                        # Safely print error logs with proper error handling and truncation
                         if ! echo "$ERROR_LOGS" | head -n 3 2>/dev/null | cut -c1-200 2>/dev/null | sed 's/^/    /' 2>/dev/null; then
                             print_warning "    [Error logs could not be displayed due to formatting issues]"
                         fi
+
+                        # Add up to 3 truncated error log lines to facts
+                        TRUNC_LOGS=$(echo "$ERROR_LOGS" | head -n 3 | cut -c1-200 | jq -R . | jq -s .)
+                        CONTROLLER_LOG_ERRORS=$(echo "$CONTROLLER_LOG_ERRORS" | jq --arg pod "$POD" --argjson lines "$TRUNC_LOGS" \
+                            '. + [{pod: $pod, lines: $lines}]')
+
+                        ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg pod "$POD" --argjson lines "$TRUNC_LOGS" \
+                            '{ingress: $ing, issue: "controller_log_errors", controller_pod: $pod, log_lines: $lines}')
+                        ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
                     else
                         print_success "  No errors in ALB controller logs for this ingress"
                     fi
@@ -119,22 +141,46 @@ for INGRESS_NAME in $INGRESSES; do
         done
     fi
 
-    # Check ingress status/address from pre-collected data
     INGRESS_ADDRESS=$(jq -r --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name) | .status.loadBalancer.ingress[0].hostname // empty' "$INGRESSES_FILE" 2>/dev/null)
 
     if [[ -z "$INGRESS_ADDRESS" ]]; then
-        HAS_ISSUES=1
+        mark_affected "$INGRESS_NAME"
+        INGRESS_HAS_ISSUE=1
         print_error "  ALB address not assigned yet (sync may be in progress or failing)"
         print_action "Check ingress controller logs and verify backend services are healthy"
+        ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" '{ingress: $ing, issue: "alb_address_not_assigned"}')
+        ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
     else
         print_success "  ALB address assigned: $INGRESS_ADDRESS"
     fi
+
+    INGRESS_FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg addr "$INGRESS_ADDRESS" \
+        --argjson event "$EVENT_SUMMARY" --argjson detected "$DETECTED_PROBLEMS" \
+        --argjson controller_errors "$CONTROLLER_LOG_ERRORS" --argjson recent "$LATEST_ERROR_EVENTS" \
+        '{ingress: $ing, address: (if $addr == "" then null else $addr end), latest_event: $event, detected_problems: $detected, controller_log_errors: $controller_errors, recent_error_events: $recent}')
+    INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$INGRESS_FACT" '. + [$i]')
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
-    INGRESS_COUNT=$(echo "$INGRESSES" | wc -w)
+INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "All $INGRESS_COUNT ingress(es) synchronized successfully with controller"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "All $INGRESS_COUNT ingress(es) synchronized successfully" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$INGRESS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have controller sync issues"
+    DETAILS=$(jq -nc \
+        --argjson facts "$INGRESS_FACTS" \
+        --argjson issues "$ISSUE_FACTS" \
+        --argjson count "$INGRESS_COUNT" \
+        '{ingress_count: $count, issue_count: ($issues | length), ingresses: $facts, issues: $issues}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+        '["Check ingress controller logs and verify backend services are healthy"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_controller_sync
+++ b/k8s/diagnose/networking/ingress_controller_sync
@@ -6,13 +6,10 @@ require_ingresses || return 0
 
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-ISSUE_FACTS="[]"
-INGRESS_FACTS="[]"
-AFFECTED_INGRESSES="[]"
+ISSUE_FACTS=()
+INGRESS_FACTS=()
+AFFECTED_INGRESSES=""
 
-mark_affected() {
-    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
-}
 
 ALB_CONTROLLER_PODS=$(jq -r '.items[].metadata.name' "$ALB_CONTROLLER_PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
@@ -67,7 +64,7 @@ for INGRESS_NAME in $INGRESSES; do
             ')
 
             if [[ -n "$ERROR_EVENTS" ]]; then
-                mark_affected "$INGRESS_NAME"
+                mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                 INGRESS_HAS_ISSUE=1
                 print_error "  Found error/warning events:"
                 echo "$ERROR_EVENTS" | sed 's/^/    /'
@@ -89,7 +86,7 @@ for INGRESS_NAME in $INGRESSES; do
 
                 ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --argjson problems "$DETECTED_PROBLEMS" --argjson events "$LATEST_ERROR_EVENTS" \
                     '{ingress: $ing, issue: "sync_errors", detected_problems: $problems, recent_events: $events}')
-                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                add_fact ISSUE_FACTS "$ISSUE"
             else
                 print_info "  Last event: $EVENT_REASON at $EVENT_TIMESTAMP"
             fi
@@ -114,7 +111,7 @@ for INGRESS_NAME in $INGRESSES; do
                         head -n 5 || true)
 
                     if [[ -n "$ERROR_LOGS" ]]; then
-                        mark_affected "$INGRESS_NAME"
+                        mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                         INGRESS_HAS_ISSUE=1
                         print_error "  Found errors in ALB controller logs:"
                         if ! echo "$ERROR_LOGS" | head -n 3 2>/dev/null | cut -c1-200 2>/dev/null | sed 's/^/    /' 2>/dev/null; then
@@ -128,7 +125,7 @@ for INGRESS_NAME in $INGRESSES; do
 
                         ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg pod "$POD" --argjson lines "$TRUNC_LOGS" \
                             '{ingress: $ing, issue: "controller_log_errors", controller_pod: $pod, log_lines: $lines}')
-                        ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                        add_fact ISSUE_FACTS "$ISSUE"
                     else
                         print_success "  No errors in ALB controller logs for this ingress"
                     fi
@@ -144,12 +141,12 @@ for INGRESS_NAME in $INGRESSES; do
     INGRESS_ADDRESS=$(jq -r --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name) | .status.loadBalancer.ingress[0].hostname // empty' "$INGRESSES_FILE" 2>/dev/null)
 
     if [[ -z "$INGRESS_ADDRESS" ]]; then
-        mark_affected "$INGRESS_NAME"
+        mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
         INGRESS_HAS_ISSUE=1
         print_error "  ALB address not assigned yet (sync may be in progress or failing)"
         print_action "Check ingress controller logs and verify backend services are healthy"
         ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" '{ingress: $ing, issue: "alb_address_not_assigned"}')
-        ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+        add_fact ISSUE_FACTS "$ISSUE"
     else
         print_success "  ALB address assigned: $INGRESS_ADDRESS"
     fi
@@ -158,11 +155,11 @@ for INGRESS_NAME in $INGRESSES; do
         --argjson event "$EVENT_SUMMARY" --argjson detected "$DETECTED_PROBLEMS" \
         --argjson controller_errors "$CONTROLLER_LOG_ERRORS" --argjson recent "$LATEST_ERROR_EVENTS" \
         '{ingress: $ing, address: (if $addr == "" then null else $addr end), latest_event: $event, detected_problems: $detected, controller_log_errors: $controller_errors, recent_error_events: $recent}')
-    INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$INGRESS_FACT" '. + [$i]')
+    add_fact INGRESS_FACTS "$INGRESS_FACT"
 done
 
 INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "All $INGRESS_COUNT ingress(es) synchronized successfully with controller"
@@ -170,17 +167,17 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "All $INGRESS_COUNT ingress(es) synchronized successfully" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$INGRESS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array INGRESS_FACTS)" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have controller sync issues"
     DETAILS=$(jq -nc \
-        --argjson facts "$INGRESS_FACTS" \
-        --argjson issues "$ISSUE_FACTS" \
+        --argjson facts "$(facts_to_json_array INGRESS_FACTS)" \
+        --argjson issues "$(facts_to_json_array ISSUE_FACTS)" \
         --argjson count "$INGRESS_COUNT" \
         '{ingress_count: $count, issue_count: ($issues | length), ingresses: $facts, issues: $issues}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_INGRESSES)" "$DETAILS" \
         '["Check ingress controller logs and verify backend services are healthy"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_existence
+++ b/k8s/diagnose/networking/ingress_existence
@@ -2,24 +2,39 @@
 # Check: Ingress Existence
 # Verifies that ingress resources exist in the namespace
 
-# Read ingresses from pre-collected data
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
 if [[ -z "$INGRESSES" ]]; then
     print_error "No ingresses found with labels $SCOPE_LABEL_SELECTOR in namespace $NAMESPACE"
     print_action "Create ingress resource to expose services externally"
-    update_check_result --status "failed" --evidence "{}"
+
+    EVIDENCE=$(evidence_json \
+        "No ingresses found in namespace $NAMESPACE" \
+        "critical" \
+        "[]" \
+        "$(jq -nc --arg ls "$SCOPE_LABEL_SELECTOR" --arg ns "$NAMESPACE" '{label_selector: $ls, namespace: $ns}')" \
+        '["Create ingress resource to expose services externally"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
     return 1
 fi
 
-INGRESS_COUNT=$(echo "$INGRESSES" | wc -w)
+INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
 print_success "Found $INGRESS_COUNT ingress(es): $INGRESSES"
+
+# Build hosts info per ingress
+INGRESS_DETAILS=$(jq -c '[.items[] | {name: .metadata.name, hosts: [.spec.rules[]?.host // empty]}]' "$INGRESSES_FILE" 2>/dev/null)
 
 # Show basic ingress info
 for INGRESS_NAME in $INGRESSES; do
-    # Get hosts from pre-collected data
     HOSTS=$(jq -r --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name) | .spec.rules[].host' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
     print_info "  $INGRESS_NAME hosts: $HOSTS"
 done
 
-update_check_result --status "success" --evidence "{}"
+EVIDENCE=$(evidence_json \
+    "Found $INGRESS_COUNT ingress(es) in namespace $NAMESPACE" \
+    "info" \
+    "[]" \
+    "$(jq -nc --argjson count "$INGRESS_COUNT" --argjson ingresses "$INGRESS_DETAILS" --arg ns "$NAMESPACE" \
+        '{ingress_count: $count, ingresses: $ingresses, namespace: $ns}')" \
+    "[]")
+update_check_result --status "success" --evidence "$EVIDENCE"

--- a/k8s/diagnose/networking/ingress_host_rules
+++ b/k8s/diagnose/networking/ingress_host_rules
@@ -2,20 +2,23 @@
 # Check: Ingress Host Rules
 # Verifies host and path rules are properly configured
 
-# Validate ingresses exist
 require_ingresses || return 0
 
-# Get ingresses
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+ISSUE_FACTS="[]"
+INGRESS_FACTS="[]"
+AFFECTED_INGRESSES="[]"
+
+mark_affected() {
+    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
+}
 
 for INGRESS_NAME in $INGRESSES; do
     INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
 
     print_info "Checking host rules for ingress: $INGRESS_NAME"
 
-    # Get ingress address/status
     INGRESS_ADDRESS=$(echo "$INGRESS_INFO" | jq -r '.status.loadBalancer.ingress[0].ip // .status.loadBalancer.ingress[0].hostname // empty')
 
     if [[ -z "$INGRESS_ADDRESS" ]]; then
@@ -24,84 +27,121 @@ for INGRESS_NAME in $INGRESSES; do
         print_info "  Ingress address: $INGRESS_ADDRESS"
     fi
 
-    # Check if there are any rules
     RULE_COUNT=$(echo "$INGRESS_INFO" | jq '.spec.rules | length' 2>/dev/null)
+    DEFAULT_BACKEND=$(echo "$INGRESS_INFO" | jq -r '.spec.defaultBackend.service.name // empty')
+
+    INGRESS_RULE_FACTS="[]"
+    INGRESS_HAS_ISSUE=0
 
     if [[ "$RULE_COUNT" -eq 0 ]]; then
-        # Check for default backend
-        DEFAULT_BACKEND=$(echo "$INGRESS_INFO" | jq -r '.spec.defaultBackend.service.name // empty')
-
         if [[ -n "$DEFAULT_BACKEND" ]]; then
             print_success "  Catch-all rule using default backend: $DEFAULT_BACKEND"
         else
-            HAS_ISSUES=1
+            mark_affected "$INGRESS_NAME"
+            INGRESS_HAS_ISSUE=1
             print_error "  No rules and no default backend configured"
             print_action "Add at least one rule or configure default backend"
+
+            ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" '{ingress: $ing, issue: "no_rules_no_default_backend"}')
+            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
         fi
-        continue
-    fi
+    else
+        RULES=$(echo "$INGRESS_INFO" | jq -c '.spec.rules[]' 2>/dev/null)
 
-    # Check each rule
-    RULES=$(echo "$INGRESS_INFO" | jq -c '.spec.rules[]' 2>/dev/null)
+        while read -r RULE; do
+            HOST=$(echo "$RULE" | jq -r '.host // "*"')
 
-    # Use process substitution to avoid subshell and preserve HAS_ISSUES updates
-    while read -r RULE; do
-        HOST=$(echo "$RULE" | jq -r '.host // "*"')
-
-        # Check if host is defined
-        if [[ "$HOST" == "*" ]]; then
-            print_warning "  Host: * (catch-all, consider specifying a hostname)"
-        else
-            print_success "  Host: $HOST"
-        fi
-
-        # Check paths
-        PATHS=$(echo "$RULE" | jq -c '.http.paths[]' 2>/dev/null)
-
-        if [[ -z "$PATHS" ]]; then
-            HAS_ISSUES=1
-            print_error "    No paths defined for host $HOST"
-            print_action "Define at least one path for this host"
-            continue
-        fi
-
-        # Use process substitution to avoid subshell and preserve HAS_ISSUES updates
-        while read -r PATH_RULE; do
-            PATH_VALUE=$(echo "$PATH_RULE" | jq -r '.path // "/"')
-            PATH_TYPE=$(echo "$PATH_RULE" | jq -r '.pathType // "Prefix"')
-            BACKEND_SERVICE=$(echo "$PATH_RULE" | jq -r '.backend.service.name')
-            BACKEND_PORT=$(echo "$PATH_RULE" | jq -r '.backend.service.port.number // .backend.service.port.name')
-
-            print_info "    Path: $PATH_VALUE ($PATH_TYPE) -> $BACKEND_SERVICE:$BACKEND_PORT"
-
-            # Validate pathType
-            if [[ "$PATH_TYPE" != "Exact" && "$PATH_TYPE" != "Prefix" && "$PATH_TYPE" != "ImplementationSpecific" ]]; then
-                HAS_ISSUES=1
-                print_error "      Invalid pathType: $PATH_TYPE (must be Exact, Prefix, or ImplementationSpecific)"
-                print_action "Use valid pathType value"
+            if [[ "$HOST" == "*" ]]; then
+                print_warning "  Host: * (catch-all, consider specifying a hostname)"
+            else
+                print_success "  Host: $HOST"
             fi
 
-            # Warn about path conventions
-            if [[ "$PATH_TYPE" == "Prefix" && "$PATH_VALUE" != "/" && ! "$PATH" =~ ^/.*[^/]$ ]]; then
-                print_warning "      Path ends with '/' - this may cause routing issues with Prefix type"
+            PATHS=$(echo "$RULE" | jq -c '.http.paths[]' 2>/dev/null)
+            HOST_PATH_FACTS="[]"
+
+            if [[ -z "$PATHS" ]]; then
+                mark_affected "$INGRESS_NAME"
+                INGRESS_HAS_ISSUE=1
+                print_error "    No paths defined for host $HOST"
+                print_action "Define at least one path for this host"
+
+                ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg host "$HOST" \
+                    '{ingress: $ing, host: $host, issue: "no_paths_for_host"}')
+                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+
+                RULE_FACT=$(jq -nc --arg host "$HOST" '{host: $host, paths: []}')
+                INGRESS_RULE_FACTS=$(echo "$INGRESS_RULE_FACTS" | jq --argjson r "$RULE_FACT" '. + [$r]')
+                continue
             fi
-        done < <(echo "$PATHS")
-    done < <(echo "$RULES")
 
-    # Check for conflicting rules
-    HOSTS=$(echo "$INGRESS_INFO" | jq -r '.spec.rules[].host' 2>/dev/null | sort)
-    DUPLICATE_HOSTS=$(echo "$HOSTS" | uniq -d)
+            while read -r PATH_RULE; do
+                PATH_VALUE=$(echo "$PATH_RULE" | jq -r '.path // "/"')
+                PATH_TYPE=$(echo "$PATH_RULE" | jq -r '.pathType // "Prefix"')
+                BACKEND_SERVICE=$(echo "$PATH_RULE" | jq -r '.backend.service.name')
+                BACKEND_PORT=$(echo "$PATH_RULE" | jq -r '.backend.service.port.number // .backend.service.port.name')
 
-    if [[ -n "$DUPLICATE_HOSTS" ]]; then
-        print_warning "  Duplicate host rules found: $DUPLICATE_HOSTS"
-        print_info "    Multiple path rules for the same host are OK, but verify they don't conflict"
+                print_info "    Path: $PATH_VALUE ($PATH_TYPE) -> $BACKEND_SERVICE:$BACKEND_PORT"
+
+                PATH_VALID=true
+                if [[ "$PATH_TYPE" != "Exact" && "$PATH_TYPE" != "Prefix" && "$PATH_TYPE" != "ImplementationSpecific" ]]; then
+                    mark_affected "$INGRESS_NAME"
+                    INGRESS_HAS_ISSUE=1
+                    PATH_VALID=false
+                    print_error "      Invalid pathType: $PATH_TYPE (must be Exact, Prefix, or ImplementationSpecific)"
+                    print_action "Use valid pathType value"
+
+                    ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg host "$HOST" --arg path "$PATH_VALUE" --arg pt "$PATH_TYPE" \
+                        '{ingress: $ing, host: $host, path: $path, path_type: $pt, issue: "invalid_path_type"}')
+                    ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                fi
+
+                PATH_FACT=$(jq -nc --arg path "$PATH_VALUE" --arg pt "$PATH_TYPE" \
+                    --arg svc "$BACKEND_SERVICE" --arg port "$BACKEND_PORT" --argjson valid "$PATH_VALID" \
+                    '{path: $path, path_type: $pt, backend_service: $svc, backend_port: $port, valid: $valid}')
+                HOST_PATH_FACTS=$(echo "$HOST_PATH_FACTS" | jq --argjson p "$PATH_FACT" '. + [$p]')
+            done < <(echo "$PATHS")
+
+            RULE_FACT=$(jq -nc --arg host "$HOST" --argjson paths "$HOST_PATH_FACTS" \
+                '{host: $host, paths: $paths}')
+            INGRESS_RULE_FACTS=$(echo "$INGRESS_RULE_FACTS" | jq --argjson r "$RULE_FACT" '. + [$r]')
+        done < <(echo "$RULES")
+
+        HOSTS=$(echo "$INGRESS_INFO" | jq -r '.spec.rules[].host' 2>/dev/null | sort)
+        DUPLICATE_HOSTS=$(echo "$HOSTS" | uniq -d)
+
+        if [[ -n "$DUPLICATE_HOSTS" ]]; then
+            print_warning "  Duplicate host rules found: $DUPLICATE_HOSTS"
+            print_info "    Multiple path rules for the same host are OK, but verify they don't conflict"
+        fi
     fi
+
+    INGRESS_FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg addr "$INGRESS_ADDRESS" --arg backend "$DEFAULT_BACKEND" \
+        --argjson rules "$INGRESS_RULE_FACTS" \
+        '{ingress: $ing, address: $addr, default_backend: (if $backend == "" then null else $backend end), rules: $rules}')
+    INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$INGRESS_FACT" '. + [$i]')
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
-    INGRESS_COUNT=$(echo "$INGRESSES" | wc -w)
+INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "Host and path rules valid for all $INGRESS_COUNT ingress(es)"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "Host and path rules valid for all $INGRESS_COUNT ingress(es)" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$INGRESS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have host/path rule issues"
+    DETAILS=$(jq -nc \
+        --argjson facts "$INGRESS_FACTS" \
+        --argjson issues "$ISSUE_FACTS" \
+        --argjson count "$INGRESS_COUNT" \
+        '{ingress_count: $count, issue_count: ($issues | length), ingresses: $facts, issues: $issues}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+        '["Add at least one rule or configure default backend; use valid pathType values"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_host_rules
+++ b/k8s/diagnose/networking/ingress_host_rules
@@ -6,13 +6,10 @@ require_ingresses || return 0
 
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-ISSUE_FACTS="[]"
-INGRESS_FACTS="[]"
-AFFECTED_INGRESSES="[]"
+ISSUE_FACTS=()
+INGRESS_FACTS=()
+AFFECTED_INGRESSES=""
 
-mark_affected() {
-    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
-}
 
 for INGRESS_NAME in $INGRESSES; do
     INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
@@ -30,20 +27,20 @@ for INGRESS_NAME in $INGRESSES; do
     RULE_COUNT=$(echo "$INGRESS_INFO" | jq '.spec.rules | length' 2>/dev/null)
     DEFAULT_BACKEND=$(echo "$INGRESS_INFO" | jq -r '.spec.defaultBackend.service.name // empty')
 
-    INGRESS_RULE_FACTS="[]"
+    INGRESS_RULE_FACTS=()
     INGRESS_HAS_ISSUE=0
 
     if [[ "$RULE_COUNT" -eq 0 ]]; then
         if [[ -n "$DEFAULT_BACKEND" ]]; then
             print_success "  Catch-all rule using default backend: $DEFAULT_BACKEND"
         else
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             INGRESS_HAS_ISSUE=1
             print_error "  No rules and no default backend configured"
             print_action "Add at least one rule or configure default backend"
 
             ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" '{ingress: $ing, issue: "no_rules_no_default_backend"}')
-            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+            add_fact ISSUE_FACTS "$ISSUE"
         fi
     else
         RULES=$(echo "$INGRESS_INFO" | jq -c '.spec.rules[]' 2>/dev/null)
@@ -58,20 +55,20 @@ for INGRESS_NAME in $INGRESSES; do
             fi
 
             PATHS=$(echo "$RULE" | jq -c '.http.paths[]' 2>/dev/null)
-            HOST_PATH_FACTS="[]"
+            HOST_PATH_FACTS=()
 
             if [[ -z "$PATHS" ]]; then
-                mark_affected "$INGRESS_NAME"
+                mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                 INGRESS_HAS_ISSUE=1
                 print_error "    No paths defined for host $HOST"
                 print_action "Define at least one path for this host"
 
                 ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg host "$HOST" \
                     '{ingress: $ing, host: $host, issue: "no_paths_for_host"}')
-                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                add_fact ISSUE_FACTS "$ISSUE"
 
                 RULE_FACT=$(jq -nc --arg host "$HOST" '{host: $host, paths: []}')
-                INGRESS_RULE_FACTS=$(echo "$INGRESS_RULE_FACTS" | jq --argjson r "$RULE_FACT" '. + [$r]')
+                add_fact INGRESS_RULE_FACTS "$RULE_FACT"
                 continue
             fi
 
@@ -85,7 +82,7 @@ for INGRESS_NAME in $INGRESSES; do
 
                 PATH_VALID=true
                 if [[ "$PATH_TYPE" != "Exact" && "$PATH_TYPE" != "Prefix" && "$PATH_TYPE" != "ImplementationSpecific" ]]; then
-                    mark_affected "$INGRESS_NAME"
+                    mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                     INGRESS_HAS_ISSUE=1
                     PATH_VALID=false
                     print_error "      Invalid pathType: $PATH_TYPE (must be Exact, Prefix, or ImplementationSpecific)"
@@ -93,18 +90,18 @@ for INGRESS_NAME in $INGRESSES; do
 
                     ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg host "$HOST" --arg path "$PATH_VALUE" --arg pt "$PATH_TYPE" \
                         '{ingress: $ing, host: $host, path: $path, path_type: $pt, issue: "invalid_path_type"}')
-                    ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                    add_fact ISSUE_FACTS "$ISSUE"
                 fi
 
                 PATH_FACT=$(jq -nc --arg path "$PATH_VALUE" --arg pt "$PATH_TYPE" \
                     --arg svc "$BACKEND_SERVICE" --arg port "$BACKEND_PORT" --argjson valid "$PATH_VALID" \
                     '{path: $path, path_type: $pt, backend_service: $svc, backend_port: $port, valid: $valid}')
-                HOST_PATH_FACTS=$(echo "$HOST_PATH_FACTS" | jq --argjson p "$PATH_FACT" '. + [$p]')
+                add_fact HOST_PATH_FACTS "$PATH_FACT"
             done < <(echo "$PATHS")
 
             RULE_FACT=$(jq -nc --arg host "$HOST" --argjson paths "$HOST_PATH_FACTS" \
                 '{host: $host, paths: $paths}')
-            INGRESS_RULE_FACTS=$(echo "$INGRESS_RULE_FACTS" | jq --argjson r "$RULE_FACT" '. + [$r]')
+            add_fact INGRESS_RULE_FACTS "$RULE_FACT"
         done < <(echo "$RULES")
 
         HOSTS=$(echo "$INGRESS_INFO" | jq -r '.spec.rules[].host' 2>/dev/null | sort)
@@ -119,11 +116,11 @@ for INGRESS_NAME in $INGRESSES; do
     INGRESS_FACT=$(jq -nc --arg ing "$INGRESS_NAME" --arg addr "$INGRESS_ADDRESS" --arg backend "$DEFAULT_BACKEND" \
         --argjson rules "$INGRESS_RULE_FACTS" \
         '{ingress: $ing, address: $addr, default_backend: (if $backend == "" then null else $backend end), rules: $rules}')
-    INGRESS_FACTS=$(echo "$INGRESS_FACTS" | jq --argjson i "$INGRESS_FACT" '. + [$i]')
+    add_fact INGRESS_FACTS "$INGRESS_FACT"
 done
 
 INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "Host and path rules valid for all $INGRESS_COUNT ingress(es)"
@@ -131,17 +128,17 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "Host and path rules valid for all $INGRESS_COUNT ingress(es)" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$INGRESS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array INGRESS_FACTS)" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have host/path rule issues"
     DETAILS=$(jq -nc \
-        --argjson facts "$INGRESS_FACTS" \
-        --argjson issues "$ISSUE_FACTS" \
+        --argjson facts "$(facts_to_json_array INGRESS_FACTS)" \
+        --argjson issues "$(facts_to_json_array ISSUE_FACTS)" \
         --argjson count "$INGRESS_COUNT" \
         '{ingress_count: $count, issue_count: ($issues | length), ingresses: $facts, issues: $issues}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_INGRESSES)" "$DETAILS" \
         '["Add at least one rule or configure default backend; use valid pathType values"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_tls_configuration
+++ b/k8s/diagnose/networking/ingress_tls_configuration
@@ -6,13 +6,10 @@ require_ingresses || return 0
 
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-ISSUE_FACTS="[]"
-TLS_FACTS="[]"
-AFFECTED_INGRESSES="[]"
+ISSUE_FACTS=()
+TLS_FACTS=()
+AFFECTED_INGRESSES=""
 
-mark_affected() {
-    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
-}
 
 for INGRESS_NAME in $INGRESSES; do
     INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
@@ -22,7 +19,7 @@ for INGRESS_NAME in $INGRESSES; do
     if [[ -z "$TLS_HOSTS" ]]; then
         print_info "Ingress $INGRESS_NAME: No TLS configuration (HTTP only)"
         FACT=$(jq -nc --arg ing "$INGRESS_NAME" '{ingress: $ing, tls_configured: false}')
-        TLS_FACTS=$(echo "$TLS_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact TLS_FACTS "$FACT"
         continue
     fi
 
@@ -60,12 +57,12 @@ for INGRESS_NAME in $INGRESSES; do
                                 '{expires: $expiry, days_remaining: $days}')
 
                             if [[ $DAYS_UNTIL_EXPIRY -lt 0 ]]; then
-                                mark_affected "$INGRESS_NAME"
+                                mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                                 INGRESS_HAS_ISSUE=1
                                 print_error "    Certificate has EXPIRED"
                                 ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg secret "$SECRET_NAME" \
                                     '{ingress: $ing, secret: $secret, issue: "certificate_expired"}')
-                                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                                add_fact ISSUE_FACTS "$ISSUE"
                             elif [[ $DAYS_UNTIL_EXPIRY -lt 30 ]]; then
                                 print_warning "    Certificate expires in $DAYS_UNTIL_EXPIRY days"
                             fi
@@ -77,17 +74,17 @@ for INGRESS_NAME in $INGRESSES; do
                     --argjson expiry "$EXPIRY_INFO" \
                     '{secret: $secret, hosts: ($hosts | split(",")), type: $type, valid: true, certificate: $expiry}')
             else
-                mark_affected "$INGRESS_NAME"
+                mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
                 INGRESS_HAS_ISSUE=1
                 print_error "  TLS Secret: $SECRET_NAME has wrong type '$SECRET_TYPE' (expected kubernetes.io/tls)"
                 SECRET_FACT=$(jq -nc --arg secret "$SECRET_NAME" --arg type "$SECRET_TYPE" \
                     '{secret: $secret, type: $type, valid: false, issue: "wrong_secret_type"}')
                 ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg secret "$SECRET_NAME" --arg type "$SECRET_TYPE" \
                     '{ingress: $ing, secret: $secret, secret_type: $type, issue: "wrong_secret_type"}')
-                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                add_fact ISSUE_FACTS "$ISSUE"
             fi
         else
-            mark_affected "$INGRESS_NAME"
+            mark_affected AFFECTED_INGRESSES "$INGRESS_NAME"
             INGRESS_HAS_ISSUE=1
             print_error "  TLS Secret: '$SECRET_NAME' not found in namespace"
             print_action "Create TLS secret or update ingress configuration"
@@ -95,18 +92,18 @@ for INGRESS_NAME in $INGRESSES; do
                 '{secret: $secret, valid: false, issue: "secret_not_found"}')
             ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg secret "$SECRET_NAME" \
                 '{ingress: $ing, secret: $secret, issue: "secret_not_found"}')
-            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+            add_fact ISSUE_FACTS "$ISSUE"
         fi
-        SECRETS_INFO=$(echo "$SECRETS_INFO" | jq --argjson s "$SECRET_FACT" '. + [$s]')
+        add_fact SECRETS_INFO "$SECRET_FACT"
     done < <(echo "$TLS_SECRETS")
 
     FACT=$(jq -nc --arg ing "$INGRESS_NAME" --argjson secrets "$SECRETS_INFO" \
         '{ingress: $ing, tls_configured: true, secrets: $secrets}')
-    TLS_FACTS=$(echo "$TLS_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+    add_fact TLS_FACTS "$FACT"
 done
 
 INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "TLS configuration valid for all $INGRESS_COUNT ingress(es)"
@@ -114,17 +111,17 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "TLS configuration valid for all $INGRESS_COUNT ingress(es)" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$TLS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array TLS_FACTS)" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have TLS issues"
     DETAILS=$(jq -nc \
-        --argjson facts "$TLS_FACTS" \
-        --argjson issues "$ISSUE_FACTS" \
+        --argjson facts "$(facts_to_json_array TLS_FACTS)" \
+        --argjson issues "$(facts_to_json_array ISSUE_FACTS)" \
         --argjson count "$INGRESS_COUNT" \
         '{ingress_count: $count, issue_count: ($issues | length), ingresses: $facts, issues: $issues}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_INGRESSES)" "$DETAILS" \
         '["Create or fix TLS secrets and ensure they are of type kubernetes.io/tls"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/networking/ingress_tls_configuration
+++ b/k8s/diagnose/networking/ingress_tls_configuration
@@ -2,92 +2,129 @@
 # Check: Ingress TLS Configuration
 # Validates TLS/SSL certificate configuration
 
-# Validate ingresses exist
 require_ingresses || return 0
 
-# Get ingresses
 INGRESSES=$(jq -r '.items[].metadata.name' "$INGRESSES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+ISSUE_FACTS="[]"
+TLS_FACTS="[]"
+AFFECTED_INGRESSES="[]"
+
+mark_affected() {
+    AFFECTED_INGRESSES=$(echo "$AFFECTED_INGRESSES" | jq --arg i "$1" 'if any(. == $i) then . else . + [$i] end')
+}
 
 for INGRESS_NAME in $INGRESSES; do
     INGRESS_INFO=$(jq --arg name "$INGRESS_NAME" '.items[] | select(.metadata.name == $name)' "$INGRESSES_FILE" 2>/dev/null)
 
-    # Check if TLS is configured
     TLS_HOSTS=$(echo "$INGRESS_INFO" | jq -r '.spec.tls[]?.hosts[]?' 2>/dev/null)
 
     if [[ -z "$TLS_HOSTS" ]]; then
         print_info "Ingress $INGRESS_NAME: No TLS configuration (HTTP only)"
+        FACT=$(jq -nc --arg ing "$INGRESS_NAME" '{ingress: $ing, tls_configured: false}')
+        TLS_FACTS=$(echo "$TLS_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
     print_info "Checking TLS configuration for ingress: $INGRESS_NAME"
-
-    # Get TLS secrets
     TLS_SECRETS=$(echo "$INGRESS_INFO" | jq -r '.spec.tls[] | "\(.secretName):\(.hosts | join(","))"' 2>/dev/null)
 
-    # Use process substitution to avoid subshell and preserve HAS_ISSUES updates
+    SECRETS_INFO="[]"
+    INGRESS_HAS_ISSUE=0
+
     while IFS=':' read -r SECRET_NAME HOSTS; do
-        # Check if secret exists in pre-collected data
         SECRET_INFO=$(jq --arg name "$SECRET_NAME" '.items[] | select(.metadata.name == $name)' "$SECRETS_FILE" 2>/dev/null)
 
         if [[ -n "$SECRET_INFO" && "$SECRET_INFO" != "null" ]]; then
             SECRET_TYPE=$(echo "$SECRET_INFO" | jq -r '.type')
 
             if [[ "$SECRET_TYPE" == "kubernetes.io/tls" ]]; then
-                # Check if secret has required keys (metadata only, no actual data)
-                SECRET_KEYS=$(echo "$SECRET_INFO" | jq -r '.metadata.annotations | keys[]' 2>/dev/null)
+                # Note: build_context strips .data for security, so we cannot inspect cert/key keys here.
+                # The Secret type kubernetes.io/tls inherently requires tls.crt and tls.key — k8s validates
+                # this at creation time. So we trust the type and validate the rest live if needed.
+                print_success "  TLS Secret: $SECRET_NAME (valid for hosts: $HOSTS)"
 
-                HAS_CERT=$(echo "$SECRET_KEYS" | grep -q "tls.crt" && echo "yes" || echo "no")
-                HAS_KEY=$(echo "$SECRET_KEYS" | grep -q "tls.key" && echo "yes" || echo "no")
+                EXPIRY_INFO="null"
+                DAYS_UNTIL_EXPIRY=""
 
-                if [[ "$HAS_CERT" == "yes" && "$HAS_KEY" == "yes" ]]; then
-                    print_success "  TLS Secret: $SECRET_NAME (valid for hosts: $HOSTS)"
+                if command -v openssl &>/dev/null; then
+                    CERT_DATA=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d 2>/dev/null)
+                    if [[ -n "$CERT_DATA" ]]; then
+                        EXPIRY=$(echo "$CERT_DATA" | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)
+                        if [[ -n "$EXPIRY" ]]; then
+                            print_info "    Certificate expires: $EXPIRY"
+                            EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s 2>/dev/null || date -j -f "%b %d %T %Y %Z" "$EXPIRY" +%s 2>/dev/null)
+                            CURRENT_EPOCH=$(date +%s)
+                            DAYS_UNTIL_EXPIRY=$(( (EXPIRY_EPOCH - CURRENT_EPOCH) / 86400 ))
+                            EXPIRY_INFO=$(jq -nc --arg expiry "$EXPIRY" --argjson days "$DAYS_UNTIL_EXPIRY" \
+                                '{expires: $expiry, days_remaining: $days}')
 
-                    # Optional: Check certificate expiration (requires openssl)
-                    if command -v openssl &>/dev/null; then
-                        CERT_DATA=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.tls\.crt}' 2>/dev/null | base64 -d 2>/dev/null)
-
-                        if [[ -n "$CERT_DATA" ]]; then
-                            EXPIRY=$(echo "$CERT_DATA" | openssl x509 -noout -enddate 2>/dev/null | cut -d= -f2)
-
-                            if [[ -n "$EXPIRY" ]]; then
-                                print_info "    Certificate expires: $EXPIRY"
-
-                                # Check if certificate is expired or expiring soon (30 days)
-                                EXPIRY_EPOCH=$(date -d "$EXPIRY" +%s 2>/dev/null || date -j -f "%b %d %T %Y %Z" "$EXPIRY" +%s 2>/dev/null)
-                                CURRENT_EPOCH=$(date +%s)
-                                DAYS_UNTIL_EXPIRY=$(( ($EXPIRY_EPOCH - $CURRENT_EPOCH) / 86400 ))
-
-                                if [[ $DAYS_UNTIL_EXPIRY -lt 0 ]]; then
-                                    HAS_ISSUES=1
-                                    print_error "    Certificate has EXPIRED"
-                                elif [[ $DAYS_UNTIL_EXPIRY -lt 30 ]]; then
-                                    print_warning "    Certificate expires in $DAYS_UNTIL_EXPIRY days"
-                                fi
+                            if [[ $DAYS_UNTIL_EXPIRY -lt 0 ]]; then
+                                mark_affected "$INGRESS_NAME"
+                                INGRESS_HAS_ISSUE=1
+                                print_error "    Certificate has EXPIRED"
+                                ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg secret "$SECRET_NAME" \
+                                    '{ingress: $ing, secret: $secret, issue: "certificate_expired"}')
+                                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                            elif [[ $DAYS_UNTIL_EXPIRY -lt 30 ]]; then
+                                print_warning "    Certificate expires in $DAYS_UNTIL_EXPIRY days"
                             fi
                         fi
                     fi
-                else
-                    HAS_ISSUES=1
-                    print_error "  TLS Secret: $SECRET_NAME missing required keys (needs tls.crt and tls.key)"
                 fi
+
+                SECRET_FACT=$(jq -nc --arg secret "$SECRET_NAME" --arg hosts "$HOSTS" --arg type "$SECRET_TYPE" \
+                    --argjson expiry "$EXPIRY_INFO" \
+                    '{secret: $secret, hosts: ($hosts | split(",")), type: $type, valid: true, certificate: $expiry}')
             else
-                HAS_ISSUES=1
+                mark_affected "$INGRESS_NAME"
+                INGRESS_HAS_ISSUE=1
                 print_error "  TLS Secret: $SECRET_NAME has wrong type '$SECRET_TYPE' (expected kubernetes.io/tls)"
+                SECRET_FACT=$(jq -nc --arg secret "$SECRET_NAME" --arg type "$SECRET_TYPE" \
+                    '{secret: $secret, type: $type, valid: false, issue: "wrong_secret_type"}')
+                ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg secret "$SECRET_NAME" --arg type "$SECRET_TYPE" \
+                    '{ingress: $ing, secret: $secret, secret_type: $type, issue: "wrong_secret_type"}')
+                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
             fi
         else
-            HAS_ISSUES=1
+            mark_affected "$INGRESS_NAME"
+            INGRESS_HAS_ISSUE=1
             print_error "  TLS Secret: '$SECRET_NAME' not found in namespace"
             print_action "Create TLS secret or update ingress configuration"
+            SECRET_FACT=$(jq -nc --arg secret "$SECRET_NAME" \
+                '{secret: $secret, valid: false, issue: "secret_not_found"}')
+            ISSUE=$(jq -nc --arg ing "$INGRESS_NAME" --arg secret "$SECRET_NAME" \
+                '{ingress: $ing, secret: $secret, issue: "secret_not_found"}')
+            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
         fi
+        SECRETS_INFO=$(echo "$SECRETS_INFO" | jq --argjson s "$SECRET_FACT" '. + [$s]')
     done < <(echo "$TLS_SECRETS")
+
+    FACT=$(jq -nc --arg ing "$INGRESS_NAME" --argjson secrets "$SECRETS_INFO" \
+        '{ingress: $ing, tls_configured: true, secrets: $secrets}')
+    TLS_FACTS=$(echo "$TLS_FACTS" | jq --argjson f "$FACT" '. + [$f]')
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
-    INGRESS_COUNT=$(echo "$INGRESSES" | wc -w)
+INGRESS_COUNT=$(echo "$INGRESSES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_INGRESSES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "TLS configuration valid for all $INGRESS_COUNT ingress(es)"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "TLS configuration valid for all $INGRESS_COUNT ingress(es)" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$TLS_FACTS" --argjson count "$INGRESS_COUNT" '{ingress_count: $count, ingresses: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $INGRESS_COUNT ingress(es) have TLS issues"
+    DETAILS=$(jq -nc \
+        --argjson facts "$TLS_FACTS" \
+        --argjson issues "$ISSUE_FACTS" \
+        --argjson count "$INGRESS_COUNT" \
+        '{ingress_count: $count, issue_count: ($issues | length), ingresses: $facts, issues: $issues}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_INGRESSES" "$DETAILS" \
+        '["Create or fix TLS secrets and ensure they are of type kubernetes.io/tls"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/container_crash_detection
+++ b/k8s/diagnose/scope/container_crash_detection
@@ -8,70 +8,121 @@ require_pods || return 0
 # Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_CRASHES=0
+# Structured fact accumulators (JSON arrays — appended per-finding)
+CRASH_LOOP_FACTS="[]"
+TERMINATED_FACTS="[]"
+HIGH_RESTART_FACTS="[]"
+AFFECTED_PODS="[]"
+
+# Action accumulators (set so we don't repeat the same action multiple times)
+HAS_ACTION_CHECK_LOGS=0
+HAS_ACTION_CHECK_TERMINATION=0
+HAS_ACTION_CHECK_INTERMITTENT=0
+
+# Counters for summary
+NUM_CRASH_LOOP=0
+NUM_TERMINATED=0
+NUM_HIGH_RESTART=0
+NUM_OOM=0
+NUM_APP_ERROR=0
+
+mark_affected() {
+    local pod="$1"
+    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$pod" 'if any(. == $p) then . else . + [$p] end')
+}
 
 for POD_NAME in $PODS; do
-      # Get pod info from pre-collected data
       POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
 
-      # Check for containers in crash states
+      # ----- CrashLoopBackOff -----
       CRASH_LOOP=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.state.waiting.reason == "CrashLoopBackOff") | .name')
 
       if [[ -n "$CRASH_LOOP" ]]; then
-          HAS_CRASHES=1
+          mark_affected "$POD_NAME"
           print_error "Pod $POD_NAME: CrashLoopBackOff in container(s): $CRASH_LOOP"
 
           for CONTAINER in $CRASH_LOOP; do
               RESTART_COUNT=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .restartCount")
               EXIT_CODE=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .lastState.terminated.exitCode // \"N/A\"")
               TERMINATION_REASON=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .lastState.terminated.reason // \"Unknown\"")
+              EXIT_MEANING=$(exit_code_meaning "$EXIT_CODE")
 
               print_warning "  Container: $CONTAINER | Restarts: $RESTART_COUNT | Exit Code: $EXIT_CODE | Reason: $TERMINATION_REASON"
+              [[ "$EXIT_MEANING" != "Unknown" ]] && print_warning "  Exit $EXIT_CODE = $EXIT_MEANING"
 
-              case "$EXIT_CODE" in
-                  137) print_warning "  Exit 137 = OOMKilled (out of memory)" ;;
-                  143) print_warning "  Exit 143 = SIGTERM (graceful termination)" ;;
-                  1)   print_warning "  Exit 1 = Application error" ;;
-                  139) print_warning "  Exit 139 = SIGSEGV (segmentation fault)" ;;
-              esac
+              NUM_CRASH_LOOP=$((NUM_CRASH_LOOP + 1))
+              [[ "$EXIT_CODE" == "137" ]] && NUM_OOM=$((NUM_OOM + 1))
+              [[ "$EXIT_CODE" == "1"   ]] && NUM_APP_ERROR=$((NUM_APP_ERROR + 1))
+
+              FACT=$(jq -nc \
+                  --arg pod "$POD_NAME" \
+                  --arg container "$CONTAINER" \
+                  --argjson restarts "${RESTART_COUNT:-0}" \
+                  --arg exit_code "$EXIT_CODE" \
+                  --arg exit_meaning "$EXIT_MEANING" \
+                  --arg reason "$TERMINATION_REASON" \
+                  '{pod: $pod, container: $container, restart_count: $restarts, exit_code: $exit_code, exit_code_meaning: $exit_meaning, termination_reason: $reason}')
+              CRASH_LOOP_FACTS=$(echo "$CRASH_LOOP_FACTS" | jq --argjson f "$FACT" '. + [$f]')
           done
 
           print_info "Last logs from $POD_NAME:"
-          kubectl logs "$POD_NAME" -n "$NAMESPACE" --tail=10 2>&1 | sed 's/^/  /'
+          # Logs are now pre-collected by build_context for problematic pods.
+          # Fall back to a live kubectl call only if the snapshot is missing.
+          PRINTED_LOGS=0
+          for CONTAINER in $CRASH_LOOP; do
+              LOG_FILE="$POD_LOGS_DIR/${POD_NAME}.${CONTAINER}.log"
+              if [[ -s "$LOG_FILE" ]]; then
+                  tail -n 10 "$LOG_FILE" | sed "s|^|  [$CONTAINER] |"
+                  PRINTED_LOGS=1
+              fi
+          done
+          if [[ $PRINTED_LOGS -eq 0 ]]; then
+              kubectl logs "$POD_NAME" -n "$NAMESPACE" --tail=10 2>&1 | sed 's/^/  /'
+          fi
           print_action "Check container logs and fix application startup issues"
+          HAS_ACTION_CHECK_LOGS=1
       fi
 
-      # Check for containers that terminated but haven't restarted yet
+      # ----- Terminated (state.terminated) -----
       TERMINATED_CONTAINERS=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.state.terminated) | .name')
 
       if [[ -n "$TERMINATED_CONTAINERS" ]]; then
-          HAS_CRASHES=1
+          mark_affected "$POD_NAME"
           print_error "Pod $POD_NAME: Terminated container(s): $TERMINATED_CONTAINERS"
 
           for CONTAINER in $TERMINATED_CONTAINERS; do
               EXIT_CODE=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .state.terminated.exitCode // \"N/A\"")
               TERMINATION_REASON=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .state.terminated.reason // \"Unknown\"")
               RESTART_COUNT=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .restartCount")
+              EXIT_MEANING=$(exit_code_meaning "$EXIT_CODE")
 
               print_warning "  Container: $CONTAINER | Exit Code: $EXIT_CODE | Reason: $TERMINATION_REASON | Restarts: $RESTART_COUNT"
+              [[ "$EXIT_MEANING" != "Unknown" ]] && print_warning "  Exit $EXIT_CODE = $EXIT_MEANING"
 
-              case "$EXIT_CODE" in
-                  137) print_warning "  Exit 137 = OOMKilled (out of memory)" ;;
-                  143) print_warning "  Exit 143 = SIGTERM (graceful termination)" ;;
-                  1)   print_warning "  Exit 1 = Application error" ;;
-                  139) print_warning "  Exit 139 = SIGSEGV (segmentation fault)" ;;
-                  0)   print_info "  Exit 0 = Clean exit (container finished successfully)" ;;
-              esac
+              NUM_TERMINATED=$((NUM_TERMINATED + 1))
+              [[ "$EXIT_CODE" == "137" ]] && NUM_OOM=$((NUM_OOM + 1))
+              [[ "$EXIT_CODE" == "1"   ]] && NUM_APP_ERROR=$((NUM_APP_ERROR + 1))
+
+              FACT=$(jq -nc \
+                  --arg pod "$POD_NAME" \
+                  --arg container "$CONTAINER" \
+                  --argjson restarts "${RESTART_COUNT:-0}" \
+                  --arg exit_code "$EXIT_CODE" \
+                  --arg exit_meaning "$EXIT_MEANING" \
+                  --arg reason "$TERMINATION_REASON" \
+                  '{pod: $pod, container: $container, restart_count: $restarts, exit_code: $exit_code, exit_code_meaning: $exit_meaning, termination_reason: $reason}')
+              TERMINATED_FACTS=$(echo "$TERMINATED_FACTS" | jq --argjson f "$FACT" '. + [$f]')
           done
 
           print_action "Check why container terminated and review logs"
+          HAS_ACTION_CHECK_TERMINATION=1
       fi
 
-      # Check for containers with high restart counts (even if currently running)
+      # ----- High restart count (currently running but unstable) -----
       HIGH_RESTART_CONTAINERS=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.restartCount >= 3) | "\(.name):\(.restartCount)"')
 
       if [[ -n "$HIGH_RESTART_CONTAINERS" ]]; then
-          HAS_CRASHES=1
+          mark_affected "$POD_NAME"
           print_warning "Pod $POD_NAME: Container(s) with high restart count:"
 
           while IFS= read -r CONTAINER_INFO; do
@@ -80,18 +131,82 @@ for POD_NAME in $PODS; do
 
               LAST_EXIT_CODE=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER_NAME\") | .lastState.terminated.exitCode // \"N/A\"")
               LAST_REASON=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER_NAME\") | .lastState.terminated.reason // \"Unknown\"")
+              LAST_EXIT_MEANING=$(exit_code_meaning "$LAST_EXIT_CODE")
 
               print_warning "  Container: $CONTAINER_NAME | Restarts: $RESTART_COUNT | Last Exit: $LAST_EXIT_CODE | Reason: $LAST_REASON"
+
+              NUM_HIGH_RESTART=$((NUM_HIGH_RESTART + 1))
+
+              FACT=$(jq -nc \
+                  --arg pod "$POD_NAME" \
+                  --arg container "$CONTAINER_NAME" \
+                  --argjson restarts "${RESTART_COUNT:-0}" \
+                  --arg last_exit "$LAST_EXIT_CODE" \
+                  --arg last_meaning "$LAST_EXIT_MEANING" \
+                  --arg last_reason "$LAST_REASON" \
+                  '{pod: $pod, container: $container, restart_count: $restarts, last_exit_code: $last_exit, last_exit_code_meaning: $last_meaning, last_termination_reason: $last_reason}')
+              HIGH_RESTART_FACTS=$(echo "$HIGH_RESTART_FACTS" | jq --argjson f "$FACT" '. + [$f]')
           done <<< "$HIGH_RESTART_CONTAINERS"
 
           print_action "Container has restarted multiple times - check for intermittent issues"
+          HAS_ACTION_CHECK_INTERMITTENT=1
       fi
 done
 
-if [[ $HAS_CRASHES -eq 0 ]]; then
-    POD_COUNT=$(echo "$PODS" | wc -w)
+# Build evidence and finalize
+TOTAL_FINDINGS=$((NUM_CRASH_LOOP + NUM_TERMINATED + NUM_HIGH_RESTART))
+POD_COUNT=$(echo "$PODS" | wc -w | tr -d ' ')
+AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+
+if [[ $TOTAL_FINDINGS -eq 0 ]]; then
     print_success "All $POD_COUNT pod(s) running without crashes or errors"
-    update_check_result --status "success" --evidence "{}"
+
+    EVIDENCE=$(evidence_json \
+        "All $POD_COUNT pod(s) running without crashes or errors" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson total "$POD_COUNT" '{pods_checked: $total}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    # Build a precise summary that highlights the most actionable cause
+    SUMMARY_PARTS=()
+    [[ $NUM_OOM -gt 0       ]] && SUMMARY_PARTS+=("$NUM_OOM OOMKilled")
+    [[ $NUM_APP_ERROR -gt 0 ]] && SUMMARY_PARTS+=("$NUM_APP_ERROR app error")
+    [[ $NUM_CRASH_LOOP -gt 0 ]] && SUMMARY_PARTS+=("$NUM_CRASH_LOOP CrashLoopBackOff")
+    [[ $NUM_TERMINATED -gt 0 ]] && SUMMARY_PARTS+=("$NUM_TERMINATED terminated")
+    [[ $NUM_HIGH_RESTART -gt 0 ]] && SUMMARY_PARTS+=("$NUM_HIGH_RESTART high-restart")
+    SUMMARY_DETAIL=$(IFS=", "; echo "${SUMMARY_PARTS[*]}")
+    SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) crashing — $SUMMARY_DETAIL"
+
+    # Aggregate suggested actions (deduplicated)
+    ACTIONS_ARR=()
+    [[ $HAS_ACTION_CHECK_LOGS -eq 1        ]] && ACTIONS_ARR+=("Check container logs and fix application startup issues")
+    [[ $HAS_ACTION_CHECK_TERMINATION -eq 1 ]] && ACTIONS_ARR+=("Check why container terminated and review logs")
+    [[ $HAS_ACTION_CHECK_INTERMITTENT -eq 1 ]] && ACTIONS_ARR+=("Container has restarted multiple times - check for intermittent issues")
+    ACTIONS_JSON=$(printf '%s\n' "${ACTIONS_ARR[@]}" | jq -R . | jq -s .)
+
+    DETAILS=$(jq -nc \
+        --argjson crash_loop "$CRASH_LOOP_FACTS" \
+        --argjson terminated "$TERMINATED_FACTS" \
+        --argjson high_restart "$HIGH_RESTART_FACTS" \
+        --argjson pod_count "$POD_COUNT" \
+        --argjson oom_count "$NUM_OOM" \
+        --argjson app_error_count "$NUM_APP_ERROR" \
+        '{
+            pod_count: $pod_count,
+            counts: {
+                crash_loop_back_off: ($crash_loop | length),
+                terminated: ($terminated | length),
+                high_restart: ($high_restart | length),
+                oom_killed: $oom_count,
+                application_error: $app_error_count
+            },
+            crash_loop_back_off: $crash_loop,
+            terminated: $terminated,
+            high_restart: $high_restart
+        }')
+
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" "$ACTIONS_JSON")
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/container_crash_detection
+++ b/k8s/diagnose/scope/container_crash_detection
@@ -54,6 +54,12 @@ for POD_NAME in $PODS; do
               [[ "$EXIT_CODE" == "137" ]] && NUM_OOM=$((NUM_OOM + 1))
               [[ "$EXIT_CODE" == "1"   ]] && NUM_APP_ERROR=$((NUM_APP_ERROR + 1))
 
+              # For CrashLoopBackOff, the useful logs are from the previous
+              # container instance (the one that crashed). The current instance
+              # is in waiting state and has no logs yet.
+              PREVIOUS_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "previous")
+              CURRENT_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "current")
+
               FACT=$(jq -nc \
                   --arg pod "$POD_NAME" \
                   --arg container "$CONTAINER" \
@@ -61,7 +67,18 @@ for POD_NAME in $PODS; do
                   --arg exit_code "$EXIT_CODE" \
                   --arg exit_meaning "$EXIT_MEANING" \
                   --arg reason "$TERMINATION_REASON" \
-                  '{pod: $pod, container: $container, restart_count: $restarts, exit_code: $exit_code, exit_code_meaning: $exit_meaning, termination_reason: $reason}')
+                  --argjson previous_logs "$PREVIOUS_LOGS" \
+                  --argjson current_logs "$CURRENT_LOGS" \
+                  '{
+                      pod: $pod,
+                      container: $container,
+                      restart_count: $restarts,
+                      exit_code: $exit_code,
+                      exit_code_meaning: $exit_meaning,
+                      termination_reason: $reason,
+                      previous_logs: $previous_logs,
+                      current_logs: $current_logs
+                  }')
               CRASH_LOOP_FACTS=$(echo "$CRASH_LOOP_FACTS" | jq --argjson f "$FACT" '. + [$f]')
           done
 
@@ -103,6 +120,12 @@ for POD_NAME in $PODS; do
               [[ "$EXIT_CODE" == "137" ]] && NUM_OOM=$((NUM_OOM + 1))
               [[ "$EXIT_CODE" == "1"   ]] && NUM_APP_ERROR=$((NUM_APP_ERROR + 1))
 
+              # For terminated (state.terminated, not waiting), the current logs
+              # are the ones from the still-terminated instance. Previous logs
+              # are also useful if the container has restarted before.
+              CURRENT_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "current")
+              PREVIOUS_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "previous")
+
               FACT=$(jq -nc \
                   --arg pod "$POD_NAME" \
                   --arg container "$CONTAINER" \
@@ -110,7 +133,18 @@ for POD_NAME in $PODS; do
                   --arg exit_code "$EXIT_CODE" \
                   --arg exit_meaning "$EXIT_MEANING" \
                   --arg reason "$TERMINATION_REASON" \
-                  '{pod: $pod, container: $container, restart_count: $restarts, exit_code: $exit_code, exit_code_meaning: $exit_meaning, termination_reason: $reason}')
+                  --argjson current_logs "$CURRENT_LOGS" \
+                  --argjson previous_logs "$PREVIOUS_LOGS" \
+                  '{
+                      pod: $pod,
+                      container: $container,
+                      restart_count: $restarts,
+                      exit_code: $exit_code,
+                      exit_code_meaning: $exit_meaning,
+                      termination_reason: $reason,
+                      current_logs: $current_logs,
+                      previous_logs: $previous_logs
+                  }')
               TERMINATED_FACTS=$(echo "$TERMINATED_FACTS" | jq --argjson f "$FACT" '. + [$f]')
           done
 
@@ -137,6 +171,11 @@ for POD_NAME in $PODS; do
 
               NUM_HIGH_RESTART=$((NUM_HIGH_RESTART + 1))
 
+              # High restart count: the container is currently running OK but
+              # has crashed multiple times. Previous logs are from the most
+              # recent crash — most useful for the AI to find a pattern.
+              PREVIOUS_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER_NAME" "previous")
+
               FACT=$(jq -nc \
                   --arg pod "$POD_NAME" \
                   --arg container "$CONTAINER_NAME" \
@@ -144,7 +183,16 @@ for POD_NAME in $PODS; do
                   --arg last_exit "$LAST_EXIT_CODE" \
                   --arg last_meaning "$LAST_EXIT_MEANING" \
                   --arg last_reason "$LAST_REASON" \
-                  '{pod: $pod, container: $container, restart_count: $restarts, last_exit_code: $last_exit, last_exit_code_meaning: $last_meaning, last_termination_reason: $last_reason}')
+                  --argjson previous_logs "$PREVIOUS_LOGS" \
+                  '{
+                      pod: $pod,
+                      container: $container,
+                      restart_count: $restarts,
+                      last_exit_code: $last_exit,
+                      last_exit_code_meaning: $last_meaning,
+                      last_termination_reason: $last_reason,
+                      previous_logs: $previous_logs
+                  }')
               HIGH_RESTART_FACTS=$(echo "$HIGH_RESTART_FACTS" | jq --argjson f "$FACT" '. + [$f]')
           done <<< "$HIGH_RESTART_CONTAINERS"
 

--- a/k8s/diagnose/scope/container_crash_detection
+++ b/k8s/diagnose/scope/container_crash_detection
@@ -8,28 +8,17 @@ require_pods || return 0
 # Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-# Structured fact accumulators (JSON arrays — appended per-finding)
-CRASH_LOOP_FACTS="[]"
-TERMINATED_FACTS="[]"
-HIGH_RESTART_FACTS="[]"
-AFFECTED_PODS="[]"
+CRASH_LOOP_FACTS=()
+TERMINATED_FACTS=()
+HIGH_RESTART_FACTS=()
+AFFECTED_PODS=""
 
-# Action accumulators (set so we don't repeat the same action multiple times)
 HAS_ACTION_CHECK_LOGS=0
 HAS_ACTION_CHECK_TERMINATION=0
 HAS_ACTION_CHECK_INTERMITTENT=0
 
-# Counters for summary
-NUM_CRASH_LOOP=0
-NUM_TERMINATED=0
-NUM_HIGH_RESTART=0
 NUM_OOM=0
 NUM_APP_ERROR=0
-
-mark_affected() {
-    local pod="$1"
-    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$pod" 'if any(. == $p) then . else . + [$p] end')
-}
 
 for POD_NAME in $PODS; do
       POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
@@ -38,7 +27,7 @@ for POD_NAME in $PODS; do
       CRASH_LOOP=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.state.waiting.reason == "CrashLoopBackOff") | .name')
 
       if [[ -n "$CRASH_LOOP" ]]; then
-          mark_affected "$POD_NAME"
+          mark_affected AFFECTED_PODS "$POD_NAME"
           print_error "Pod $POD_NAME: CrashLoopBackOff in container(s): $CRASH_LOOP"
 
           for CONTAINER in $CRASH_LOOP; do
@@ -50,13 +39,11 @@ for POD_NAME in $PODS; do
               print_warning "  Container: $CONTAINER | Restarts: $RESTART_COUNT | Exit Code: $EXIT_CODE | Reason: $TERMINATION_REASON"
               [[ "$EXIT_MEANING" != "Unknown" ]] && print_warning "  Exit $EXIT_CODE = $EXIT_MEANING"
 
-              NUM_CRASH_LOOP=$((NUM_CRASH_LOOP + 1))
               [[ "$EXIT_CODE" == "137" ]] && NUM_OOM=$((NUM_OOM + 1))
               [[ "$EXIT_CODE" == "1"   ]] && NUM_APP_ERROR=$((NUM_APP_ERROR + 1))
 
-              # For CrashLoopBackOff, the useful logs are from the previous
-              # container instance (the one that crashed). The current instance
-              # is in waiting state and has no logs yet.
+              # CrashLoopBackOff: the useful logs are from the previous container
+              # instance. The current instance is in waiting state with no logs yet.
               PREVIOUS_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "previous")
               CURRENT_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "current")
 
@@ -79,7 +66,7 @@ for POD_NAME in $PODS; do
                       previous_logs: $previous_logs,
                       current_logs: $current_logs
                   }')
-              CRASH_LOOP_FACTS=$(echo "$CRASH_LOOP_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+              add_fact CRASH_LOOP_FACTS "$FACT"
           done
 
           print_info "Last logs from $POD_NAME:"
@@ -104,7 +91,7 @@ for POD_NAME in $PODS; do
       TERMINATED_CONTAINERS=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.state.terminated) | .name')
 
       if [[ -n "$TERMINATED_CONTAINERS" ]]; then
-          mark_affected "$POD_NAME"
+          mark_affected AFFECTED_PODS "$POD_NAME"
           print_error "Pod $POD_NAME: Terminated container(s): $TERMINATED_CONTAINERS"
 
           for CONTAINER in $TERMINATED_CONTAINERS; do
@@ -116,13 +103,11 @@ for POD_NAME in $PODS; do
               print_warning "  Container: $CONTAINER | Exit Code: $EXIT_CODE | Reason: $TERMINATION_REASON | Restarts: $RESTART_COUNT"
               [[ "$EXIT_MEANING" != "Unknown" ]] && print_warning "  Exit $EXIT_CODE = $EXIT_MEANING"
 
-              NUM_TERMINATED=$((NUM_TERMINATED + 1))
               [[ "$EXIT_CODE" == "137" ]] && NUM_OOM=$((NUM_OOM + 1))
               [[ "$EXIT_CODE" == "1"   ]] && NUM_APP_ERROR=$((NUM_APP_ERROR + 1))
 
-              # For terminated (state.terminated, not waiting), the current logs
-              # are the ones from the still-terminated instance. Previous logs
-              # are also useful if the container has restarted before.
+              # state.terminated (not waiting): current logs are from the still-
+              # terminated instance; previous matters if the container restarted before.
               CURRENT_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "current")
               PREVIOUS_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "previous")
 
@@ -145,7 +130,7 @@ for POD_NAME in $PODS; do
                       current_logs: $current_logs,
                       previous_logs: $previous_logs
                   }')
-              TERMINATED_FACTS=$(echo "$TERMINATED_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+              add_fact TERMINATED_FACTS "$FACT"
           done
 
           print_action "Check why container terminated and review logs"
@@ -156,7 +141,7 @@ for POD_NAME in $PODS; do
       HIGH_RESTART_CONTAINERS=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.restartCount >= 3) | "\(.name):\(.restartCount)"')
 
       if [[ -n "$HIGH_RESTART_CONTAINERS" ]]; then
-          mark_affected "$POD_NAME"
+          mark_affected AFFECTED_PODS "$POD_NAME"
           print_warning "Pod $POD_NAME: Container(s) with high restart count:"
 
           while IFS= read -r CONTAINER_INFO; do
@@ -169,11 +154,8 @@ for POD_NAME in $PODS; do
 
               print_warning "  Container: $CONTAINER_NAME | Restarts: $RESTART_COUNT | Last Exit: $LAST_EXIT_CODE | Reason: $LAST_REASON"
 
-              NUM_HIGH_RESTART=$((NUM_HIGH_RESTART + 1))
-
-              # High restart count: the container is currently running OK but
-              # has crashed multiple times. Previous logs are from the most
-              # recent crash — most useful for the AI to find a pattern.
+              # High restart count: container running OK now but crashed multiple
+              # times before. Previous logs are from the most recent crash.
               PREVIOUS_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER_NAME" "previous")
 
               FACT=$(jq -nc \
@@ -193,7 +175,7 @@ for POD_NAME in $PODS; do
                       last_termination_reason: $last_reason,
                       previous_logs: $previous_logs
                   }')
-              HIGH_RESTART_FACTS=$(echo "$HIGH_RESTART_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+              add_fact HIGH_RESTART_FACTS "$FACT"
           done <<< "$HIGH_RESTART_CONTAINERS"
 
           print_action "Container has restarted multiple times - check for intermittent issues"
@@ -201,10 +183,17 @@ for POD_NAME in $PODS; do
       fi
 done
 
-# Build evidence and finalize
+POD_COUNT=$(jq '.items | length' "$PODS_FILE")
+NUM_CRASH_LOOP=${#CRASH_LOOP_FACTS[@]}
+NUM_TERMINATED=${#TERMINATED_FACTS[@]}
+NUM_HIGH_RESTART=${#HIGH_RESTART_FACTS[@]}
 TOTAL_FINDINGS=$((NUM_CRASH_LOOP + NUM_TERMINATED + NUM_HIGH_RESTART))
-POD_COUNT=$(echo "$PODS" | wc -w | tr -d ' ')
-AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+AFFECTED_COUNT=$(echo $AFFECTED_PODS | wc -w | tr -d ' ')
+
+CRASH_LOOP_FACTS_JSON=$(facts_to_json_array CRASH_LOOP_FACTS)
+TERMINATED_FACTS_JSON=$(facts_to_json_array TERMINATED_FACTS)
+HIGH_RESTART_FACTS_JSON=$(facts_to_json_array HIGH_RESTART_FACTS)
+AFFECTED_PODS_JSON=$(set_to_json_array AFFECTED_PODS)
 
 if [[ $TOTAL_FINDINGS -eq 0 ]]; then
     print_success "All $POD_COUNT pod(s) running without crashes or errors"
@@ -217,7 +206,6 @@ if [[ $TOTAL_FINDINGS -eq 0 ]]; then
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    # Build a precise summary that highlights the most actionable cause
     SUMMARY_PARTS=()
     [[ $NUM_OOM -gt 0       ]] && SUMMARY_PARTS+=("$NUM_OOM OOMKilled")
     [[ $NUM_APP_ERROR -gt 0 ]] && SUMMARY_PARTS+=("$NUM_APP_ERROR app error")
@@ -227,17 +215,16 @@ else
     SUMMARY_DETAIL=$(IFS=", "; echo "${SUMMARY_PARTS[*]}")
     SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) crashing — $SUMMARY_DETAIL"
 
-    # Aggregate suggested actions (deduplicated)
     ACTIONS_ARR=()
     [[ $HAS_ACTION_CHECK_LOGS -eq 1        ]] && ACTIONS_ARR+=("Check container logs and fix application startup issues")
     [[ $HAS_ACTION_CHECK_TERMINATION -eq 1 ]] && ACTIONS_ARR+=("Check why container terminated and review logs")
     [[ $HAS_ACTION_CHECK_INTERMITTENT -eq 1 ]] && ACTIONS_ARR+=("Container has restarted multiple times - check for intermittent issues")
-    ACTIONS_JSON=$(printf '%s\n' "${ACTIONS_ARR[@]}" | jq -R . | jq -s .)
+    ACTIONS_JSON=$(printf '%s\n' "${ACTIONS_ARR[@]}" | lines_to_json_array)
 
     DETAILS=$(jq -nc \
-        --argjson crash_loop "$CRASH_LOOP_FACTS" \
-        --argjson terminated "$TERMINATED_FACTS" \
-        --argjson high_restart "$HIGH_RESTART_FACTS" \
+        --argjson crash_loop "$CRASH_LOOP_FACTS_JSON" \
+        --argjson terminated "$TERMINATED_FACTS_JSON" \
+        --argjson high_restart "$HIGH_RESTART_FACTS_JSON" \
         --argjson pod_count "$POD_COUNT" \
         --argjson oom_count "$NUM_OOM" \
         --argjson app_error_count "$NUM_APP_ERROR" \
@@ -255,6 +242,6 @@ else
             high_restart: $high_restart
         }')
 
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" "$ACTIONS_JSON")
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS_JSON" "$DETAILS" "$ACTIONS_JSON")
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/container_port_health
+++ b/k8s/diagnose/scope/container_port_health
@@ -2,52 +2,57 @@
 # Check: Container Port Health
 # Validates that containers are actually listening on their declared ports
 
-# Validate pods exist
 require_pods || return 0
 
-# Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_PORT_ISSUES=0
 CONTAINERS_TESTED=0
 CONTAINERS_SKIPPED=0
+ISSUE_FACTS="[]"
+POD_FACTS="[]"
+AFFECTED_PODS="[]"
+
+mark_affected() {
+    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
+}
 
 for POD_NAME in $PODS; do
-    # Get pod info from pre-collected data
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
 
-    # Check if pod is running
     POD_PHASE=$(echo "$POD_INFO" | jq -r '.status.phase')
     if [[ "$POD_PHASE" != "Running" ]]; then
         print_warning "Pod $POD_NAME: Not running (phase: $POD_PHASE), skipping port checks"
+        FACT=$(jq -nc --arg p "$POD_NAME" --arg phase "$POD_PHASE" '{pod: $p, status: "skipped", reason: "not_running", phase: $phase}')
+        POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
-    # Get pod IP
     POD_IP=$(echo "$POD_INFO" | jq -r '.status.podIP')
     if [[ -z "$POD_IP" || "$POD_IP" == "null" ]]; then
         print_warning "Pod $POD_NAME: No IP assigned, skipping port checks"
+        FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, status: "skipped", reason: "no_ip"}')
+        POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
     print_info "Checking pod $POD_NAME:"
 
-    # Get all containers with their ports
     CONTAINERS=$(echo "$POD_INFO" | jq -r '.spec.containers[] | @base64')
+    POD_CONTAINER_FACTS="[]"
 
     for CONTAINER_B64 in $CONTAINERS; do
         CONTAINER_DATA=$(echo "$CONTAINER_B64" | base64 -d)
         CONTAINER_NAME=$(echo "$CONTAINER_DATA" | jq -r '.name')
 
-        # Check container status before testing ports
         CONTAINER_STATUS=$(echo "$POD_INFO" | jq -r --arg name "$CONTAINER_NAME" '.status.containerStatuses[]? | select(.name == $name)')
 
         if [[ -z "$CONTAINER_STATUS" ]]; then
             print_warning "  Container '$CONTAINER_NAME': Status not found, skipping"
+            CFACT=$(jq -nc --arg c "$CONTAINER_NAME" '{container: $c, status: "skipped", reason: "no_status"}')
+            POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
             continue
         fi
 
-        # Check if container is ready
         CONTAINER_READY=$(echo "$CONTAINER_STATUS" | jq -r '.ready')
         CONTAINER_STATE=$(echo "$CONTAINER_STATUS" | jq -r '
             if .state.running then "running"
@@ -57,28 +62,26 @@ for POD_NAME in $PODS; do
             end
         ')
 
-        # Get declared ports for this container
         CONTAINER_PORTS=$(echo "$CONTAINER_DATA" | jq -r '.ports[]? | .containerPort' | tr '\n' ' ')
 
         if [[ -z "$CONTAINER_PORTS" ]]; then
             print_info "  Container '$CONTAINER_NAME': No ports declared"
+            CFACT=$(jq -nc --arg c "$CONTAINER_NAME" '{container: $c, status: "no_ports_declared"}')
+            POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
             continue
         fi
 
         print_info "  Container '$CONTAINER_NAME':"
 
-        # If container is not running, explain why we can't test ports
         if [[ "$CONTAINER_STATE" != "running" ]]; then
             if [[ "$CONTAINER_STATE" == "waiting" ]]; then
                 WAITING_REASON=$(echo "$CONTAINER_STATUS" | jq -r '.state.waiting.reason // "Unknown"')
                 WAITING_MESSAGE=$(echo "$CONTAINER_STATUS" | jq -r '.state.waiting.message // ""')
 
-                # Check if it's a normal startup state or a problem
                 case "$WAITING_REASON" in
                     ContainerCreating|PodInitializing|Pulling)
                         CONTAINERS_SKIPPED=$((CONTAINERS_SKIPPED + 1))
                         print_info "    Container is starting ($WAITING_REASON) - skipping port checks"
-                        continue
                         ;;
                     CrashLoopBackOff|ImagePullBackOff|ErrImagePull)
                         CONTAINERS_SKIPPED=$((CONTAINERS_SKIPPED + 1))
@@ -87,37 +90,46 @@ for POD_NAME in $PODS; do
                             print_warning "    Message: $WAITING_MESSAGE"
                         fi
                         print_action "Fix container startup issues (check container_crash_detection results)"
-                        continue
                         ;;
                     *)
                         CONTAINERS_SKIPPED=$((CONTAINERS_SKIPPED + 1))
                         print_warning "    Container waiting: $WAITING_REASON - skipping port checks"
-                        continue
                         ;;
                 esac
+
+                CFACT=$(jq -nc --arg c "$CONTAINER_NAME" --arg reason "$WAITING_REASON" \
+                    '{container: $c, status: "skipped", state: "waiting", reason: $reason}')
+                POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
+                continue
             elif [[ "$CONTAINER_STATE" == "terminated" ]]; then
                 EXIT_CODE=$(echo "$CONTAINER_STATUS" | jq -r '.state.terminated.exitCode // "N/A"')
                 TERMINATION_REASON=$(echo "$CONTAINER_STATUS" | jq -r '.state.terminated.reason // "Unknown"')
                 CONTAINERS_SKIPPED=$((CONTAINERS_SKIPPED + 1))
                 print_warning "    Cannot test ports - container terminated (Exit: $EXIT_CODE, Reason: $TERMINATION_REASON)"
                 print_action "Fix container termination (check container_crash_detection results)"
+
+                CFACT=$(jq -nc --arg c "$CONTAINER_NAME" --arg ec "$EXIT_CODE" --arg reason "$TERMINATION_REASON" \
+                    '{container: $c, status: "skipped", state: "terminated", exit_code: $ec, termination_reason: $reason}')
+                POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
                 continue
             else
                 print_warning "    Container in unknown state - skipping port checks"
+                CFACT=$(jq -nc --arg c "$CONTAINER_NAME" '{container: $c, status: "skipped", state: "unknown"}')
+                POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
                 continue
             fi
         fi
 
-        # Container is running - check if it's ready
         if [[ "$CONTAINER_READY" != "true" ]]; then
             print_warning "    Container is running but not ready - port connectivity may fail"
         fi
 
-        # Test connectivity to each declared port from agent
         CONTAINERS_TESTED=$((CONTAINERS_TESTED + 1))
 
+        PORT_RESULTS="[]"
+        CONTAINER_HAS_PORT_ISSUE=0
+
         for PORT in $CONTAINER_PORTS; do
-            # Try nc first, then timeout + /dev/tcp, then curl
             if command -v nc >/dev/null 2>&1; then
                 timeout 2 nc -z -w 1 "$POD_IP" "$PORT" >/dev/null 2>&1
                 CONNECTIVITY_EXIT_CODE=$?
@@ -129,33 +141,77 @@ for POD_NAME in $PODS; do
                 CONNECTIVITY_EXIT_CODE=$?
             else
                 print_warning "    Port $PORT: Cannot test (nc/timeout/curl not available in agent)"
+                PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson port "$PORT" '. + [{port: $port, status: "untestable"}]')
                 continue
             fi
 
             if [[ $CONNECTIVITY_EXIT_CODE -eq 0 ]]; then
                 print_success "    Port $PORT: ✓ Listening"
+                PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson port "$PORT" '. + [{port: $port, status: "listening"}]')
             else
-                HAS_PORT_ISSUES=1
+                CONTAINER_HAS_PORT_ISSUE=1
+                mark_affected "$POD_NAME"
                 print_error "    Port $PORT: ✗ Declared but not listening or unreachable"
                 print_action "Check application configuration and ensure it listens on port $PORT"
+                PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson port "$PORT" '. + [{port: $port, status: "not_listening"}]')
+
+                ISSUE=$(jq -nc --arg pod "$POD_NAME" --arg c "$CONTAINER_NAME" --argjson port "$PORT" \
+                    '{pod: $pod, container: $c, port: $port, issue: "port_not_listening"}')
+                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
             fi
         done
+
+        CFACT=$(jq -nc --arg c "$CONTAINER_NAME" --argjson ports "$PORT_RESULTS" --arg ready "$CONTAINER_READY" \
+            --argjson tested true \
+            '{container: $c, status: "tested", container_ready: ($ready == "true"), ports: $ports}')
+        POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
     done
+
+    POD_FACT=$(jq -nc --arg p "$POD_NAME" --arg ip "$POD_IP" --argjson containers "$POD_CONTAINER_FACTS" \
+        '{pod: $p, pod_ip: $ip, containers: $containers}')
+    POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$POD_FACT" '. + [$f]')
 done
 
 echo ""
+
+DETAILS=$(jq -nc \
+    --argjson tested "$CONTAINERS_TESTED" \
+    --argjson skipped "$CONTAINERS_SKIPPED" \
+    --argjson facts "$POD_FACTS" \
+    --argjson issues "$ISSUE_FACTS" \
+    '{
+        containers_tested: $tested,
+        containers_skipped: $skipped,
+        issue_count: ($issues | length),
+        pods: $facts,
+        issues: $issues
+    }')
+
 if [[ $CONTAINERS_TESTED -eq 0 ]]; then
-    # No containers were tested - all were skipped
     print_info "All containers skipped - no port checks could be performed"
-    update_check_result --status "skipped" --evidence "{\"tested\":$CONTAINERS_TESTED,\"skipped\":$CONTAINERS_SKIPPED}"
-elif [[ $HAS_PORT_ISSUES -eq 0 ]]; then
-    # Some/all containers were tested and all passed
+    EVIDENCE=$(evidence_json \
+        "All containers skipped — no port checks performed" \
+        "info" \
+        "[]" \
+        "$DETAILS" \
+        "[]")
+    update_check_result --status "skipped" --evidence "$EVIDENCE"
+elif [[ $(echo "$ISSUE_FACTS" | jq 'length') -eq 0 ]]; then
     print_success "Port connectivity verified on $CONTAINERS_TESTED container(s)"
-    update_check_result --status "success" --evidence "{\"tested\":$CONTAINERS_TESTED,\"skipped\":$CONTAINERS_SKIPPED}"
+    EVIDENCE=$(evidence_json \
+        "Port connectivity verified on $CONTAINERS_TESTED container(s)" \
+        "info" \
+        "[]" \
+        "$DETAILS" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    # Some containers were tested and had issues
     if [[ $CONTAINERS_SKIPPED -gt 0 ]]; then
         print_warning "Port issues found ($CONTAINERS_TESTED tested, $CONTAINERS_SKIPPED skipped)"
     fi
-    update_check_result --status "failed" --evidence "{\"tested\":$CONTAINERS_TESTED,\"skipped\":$CONTAINERS_SKIPPED}"
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    SUMMARY="$AFFECTED_COUNT pod(s) with port connectivity issues"
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+        '["Check application configuration and ensure it listens on declared ports"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/container_port_health
+++ b/k8s/diagnose/scope/container_port_health
@@ -8,13 +8,10 @@ PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
 CONTAINERS_TESTED=0
 CONTAINERS_SKIPPED=0
-ISSUE_FACTS="[]"
-POD_FACTS="[]"
-AFFECTED_PODS="[]"
+ISSUE_FACTS=()
+POD_FACTS=()
+AFFECTED_PODS=""
 
-mark_affected() {
-    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
-}
 
 for POD_NAME in $PODS; do
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
@@ -23,7 +20,7 @@ for POD_NAME in $PODS; do
     if [[ "$POD_PHASE" != "Running" ]]; then
         print_warning "Pod $POD_NAME: Not running (phase: $POD_PHASE), skipping port checks"
         FACT=$(jq -nc --arg p "$POD_NAME" --arg phase "$POD_PHASE" '{pod: $p, status: "skipped", reason: "not_running", phase: $phase}')
-        POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact POD_FACTS "$FACT"
         continue
     fi
 
@@ -31,14 +28,14 @@ for POD_NAME in $PODS; do
     if [[ -z "$POD_IP" || "$POD_IP" == "null" ]]; then
         print_warning "Pod $POD_NAME: No IP assigned, skipping port checks"
         FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, status: "skipped", reason: "no_ip"}')
-        POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact POD_FACTS "$FACT"
         continue
     fi
 
     print_info "Checking pod $POD_NAME:"
 
     CONTAINERS=$(echo "$POD_INFO" | jq -r '.spec.containers[] | @base64')
-    POD_CONTAINER_FACTS="[]"
+    POD_CONTAINER_FACTS=()
 
     for CONTAINER_B64 in $CONTAINERS; do
         CONTAINER_DATA=$(echo "$CONTAINER_B64" | base64 -d)
@@ -49,7 +46,7 @@ for POD_NAME in $PODS; do
         if [[ -z "$CONTAINER_STATUS" ]]; then
             print_warning "  Container '$CONTAINER_NAME': Status not found, skipping"
             CFACT=$(jq -nc --arg c "$CONTAINER_NAME" '{container: $c, status: "skipped", reason: "no_status"}')
-            POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
+            add_fact POD_CONTAINER_FACTS "$CFACT"
             continue
         fi
 
@@ -67,7 +64,7 @@ for POD_NAME in $PODS; do
         if [[ -z "$CONTAINER_PORTS" ]]; then
             print_info "  Container '$CONTAINER_NAME': No ports declared"
             CFACT=$(jq -nc --arg c "$CONTAINER_NAME" '{container: $c, status: "no_ports_declared"}')
-            POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
+            add_fact POD_CONTAINER_FACTS "$CFACT"
             continue
         fi
 
@@ -99,7 +96,7 @@ for POD_NAME in $PODS; do
 
                 CFACT=$(jq -nc --arg c "$CONTAINER_NAME" --arg reason "$WAITING_REASON" \
                     '{container: $c, status: "skipped", state: "waiting", reason: $reason}')
-                POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
+                add_fact POD_CONTAINER_FACTS "$CFACT"
                 continue
             elif [[ "$CONTAINER_STATE" == "terminated" ]]; then
                 EXIT_CODE=$(echo "$CONTAINER_STATUS" | jq -r '.state.terminated.exitCode // "N/A"')
@@ -110,12 +107,12 @@ for POD_NAME in $PODS; do
 
                 CFACT=$(jq -nc --arg c "$CONTAINER_NAME" --arg ec "$EXIT_CODE" --arg reason "$TERMINATION_REASON" \
                     '{container: $c, status: "skipped", state: "terminated", exit_code: $ec, termination_reason: $reason}')
-                POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
+                add_fact POD_CONTAINER_FACTS "$CFACT"
                 continue
             else
                 print_warning "    Container in unknown state - skipping port checks"
                 CFACT=$(jq -nc --arg c "$CONTAINER_NAME" '{container: $c, status: "skipped", state: "unknown"}')
-                POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
+                add_fact POD_CONTAINER_FACTS "$CFACT"
                 continue
             fi
         fi
@@ -126,7 +123,7 @@ for POD_NAME in $PODS; do
 
         CONTAINERS_TESTED=$((CONTAINERS_TESTED + 1))
 
-        PORT_RESULTS="[]"
+        PORT_RESULTS=()
         CONTAINER_HAS_PORT_ISSUE=0
 
         for PORT in $CONTAINER_PORTS; do
@@ -150,7 +147,7 @@ for POD_NAME in $PODS; do
                 PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson port "$PORT" '. + [{port: $port, status: "listening"}]')
             else
                 CONTAINER_HAS_PORT_ISSUE=1
-                mark_affected "$POD_NAME"
+                mark_affected AFFECTED_PODS "$POD_NAME"
                 print_error "    Port $PORT: ✗ Declared but not listening or unreachable"
                 print_action "Check application configuration and ensure it listens on port $PORT"
                 PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson port "$PORT" '. + [{port: $port, status: "not_listening"}]')
@@ -163,19 +160,19 @@ for POD_NAME in $PODS; do
                 ISSUE=$(jq -nc --arg pod "$POD_NAME" --arg c "$CONTAINER_NAME" --argjson port "$PORT" \
                     --argjson logs "$CURRENT_LOGS" \
                     '{pod: $pod, container: $c, port: $port, issue: "port_not_listening", container_logs: $logs}')
-                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+                add_fact ISSUE_FACTS "$ISSUE"
             fi
         done
 
-        CFACT=$(jq -nc --arg c "$CONTAINER_NAME" --argjson ports "$PORT_RESULTS" --arg ready "$CONTAINER_READY" \
+        CFACT=$(jq -nc --arg c "$CONTAINER_NAME" --argjson ports "$(facts_to_json_array PORT_RESULTS)" --arg ready "$CONTAINER_READY" \
             --argjson tested true \
             '{container: $c, status: "tested", container_ready: ($ready == "true"), ports: $ports}')
-        POD_CONTAINER_FACTS=$(echo "$POD_CONTAINER_FACTS" | jq --argjson c "$CFACT" '. + [$c]')
+        add_fact POD_CONTAINER_FACTS "$CFACT"
     done
 
-    POD_FACT=$(jq -nc --arg p "$POD_NAME" --arg ip "$POD_IP" --argjson containers "$POD_CONTAINER_FACTS" \
+    POD_FACT=$(jq -nc --arg p "$POD_NAME" --arg ip "$POD_IP" --argjson containers "$(facts_to_json_array POD_CONTAINER_FACTS)" \
         '{pod: $p, pod_ip: $ip, containers: $containers}')
-    POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$POD_FACT" '. + [$f]')
+    add_fact POD_FACTS "$POD_FACT"
 done
 
 echo ""
@@ -183,8 +180,8 @@ echo ""
 DETAILS=$(jq -nc \
     --argjson tested "$CONTAINERS_TESTED" \
     --argjson skipped "$CONTAINERS_SKIPPED" \
-    --argjson facts "$POD_FACTS" \
-    --argjson issues "$ISSUE_FACTS" \
+    --argjson facts "$(facts_to_json_array POD_FACTS)" \
+    --argjson issues "$(facts_to_json_array ISSUE_FACTS)" \
     '{
         containers_tested: $tested,
         containers_skipped: $skipped,
@@ -215,9 +212,9 @@ else
     if [[ $CONTAINERS_SKIPPED -gt 0 ]]; then
         print_warning "Port issues found ($CONTAINERS_TESTED tested, $CONTAINERS_SKIPPED skipped)"
     fi
-    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | wc -w | tr -d ' ')
     SUMMARY="$AFFECTED_COUNT pod(s) with port connectivity issues"
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_PODS)" "$DETAILS" \
         '["Check application configuration and ensure it listens on declared ports"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/container_port_health
+++ b/k8s/diagnose/scope/container_port_health
@@ -155,8 +155,14 @@ for POD_NAME in $PODS; do
                 print_action "Check application configuration and ensure it listens on port $PORT"
                 PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson port "$PORT" '. + [{port: $port, status: "not_listening"}]')
 
+                # The container is running but not listening on its declared
+                # port — current logs likely show why (binding error, config
+                # mismatch, app stuck during startup).
+                CURRENT_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER_NAME" "current")
+
                 ISSUE=$(jq -nc --arg pod "$POD_NAME" --arg c "$CONTAINER_NAME" --argjson port "$PORT" \
-                    '{pod: $pod, container: $c, port: $port, issue: "port_not_listening"}')
+                    --argjson logs "$CURRENT_LOGS" \
+                    '{pod: $pod, container: $c, port: $port, issue: "port_not_listening", container_logs: $logs}')
                 ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
             fi
         done

--- a/k8s/diagnose/scope/health_probe_endpoints
+++ b/k8s/diagnose/scope/health_probe_endpoints
@@ -83,6 +83,14 @@ test_http_probe() {
         classification="warning_connection"
     fi
 
+    # On failure, attach the container's current logs to the issue so the AI
+    # summarizer can correlate "probe says X" with "app logs say Y" without
+    # any extra calls.
+    local container_logs="[]"
+    if [[ "$classification" != "success" ]]; then
+        container_logs=$(read_log_tail "$pod" "$container" "current")
+    fi
+
     PROBE_FACT=$(jq -nc --arg pod "$pod" --arg c "$container" --arg pt "$probe_type" \
         --arg path "$path" --arg port "$port" --arg scheme "$scheme" \
         --arg http_response "$response" --arg status "$result_status" \
@@ -93,7 +101,8 @@ test_http_probe() {
         ISSUE=$(jq -nc --arg pod "$pod" --arg c "$container" --arg pt "$probe_type" \
             --arg path "$path" --arg port "$port" --arg http_response "$response" \
             --arg classification "$classification" \
-            '{pod: $pod, container: $c, probe_type: $pt, path: $path, port: $port, http_response: $http_response, issue: $classification}')
+            --argjson logs "$container_logs" \
+            '{pod: $pod, container: $c, probe_type: $pt, path: $path, port: $port, http_response: $http_response, issue: $classification, container_logs: $logs}')
         ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
         return 1
     fi

--- a/k8s/diagnose/scope/health_probe_endpoints
+++ b/k8s/diagnose/scope/health_probe_endpoints
@@ -2,10 +2,8 @@
 # Check: Health Probe Endpoints
 # Validates that liveness and readiness probe endpoints are configured and responding correctly
 
-# Validate pods exist
 require_pods || return 0
 
-# Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
 HAS_PROBE_ISSUES=0
@@ -13,27 +11,116 @@ HAS_PROBE_WARNINGS=0
 CONTAINERS_TESTED=0
 CONTAINERS_SKIPPED=0
 
+PROBE_FACTS="[]"
+ISSUE_FACTS="[]"
+POD_FACTS="[]"
+AFFECTED_PODS="[]"
+
+mark_affected() {
+    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
+}
+
+# Probe a single HTTP endpoint and emit a JSON fact + classification
+# Args: pod, container, probe_type (Readiness/Liveness/Startup), path, port, scheme
+test_http_probe() {
+    local pod="$1" container="$2" probe_type="$3" path="$4" port="$5" scheme="$6"
+    local url="${scheme,,}://$POD_IP:$port$path"
+    local response="" exit_code=0
+
+    if command -v curl >/dev/null 2>&1; then
+        if [[ "${scheme^^}" == "HTTPS" ]]; then
+            response=$(curl -k -s -o /dev/null -w '%{http_code}' --max-time 2 "$url" 2>&1)
+        else
+            response=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$url" 2>&1)
+        fi
+        exit_code=$?
+    elif command -v wget >/dev/null 2>&1; then
+        if [[ "${scheme^^}" == "HTTPS" ]]; then
+            response=$(wget --no-check-certificate -O /dev/null --timeout=2 "$url" 2>&1)
+        else
+            response=$(wget -O /dev/null --timeout=2 "$url" 2>&1)
+        fi
+        exit_code=$?
+        if [[ $exit_code -eq 0 ]]; then
+            response="200"
+        else
+            local err
+            err=$(echo "$response" | grep -iE "failed:|connection refused|timed? ?out|cannot connect|unable to|network|unreachable" | head -1)
+            if [[ -n "$err" ]]; then
+                response=$(echo "$err" | cut -c1-80)
+            else
+                response="wget failed with exit code $exit_code"
+            fi
+        fi
+    else
+        print_warning "    $probe_type Probe on $scheme://$port$path: Cannot test (curl/wget not available in agent)"
+        PROBE_FACT=$(jq -nc --arg pod "$pod" --arg c "$container" --arg pt "$probe_type" \
+            --arg path "$path" --arg port "$port" --arg scheme "$scheme" \
+            '{pod: $pod, container: $c, probe_type: $pt, kind: "httpGet", path: $path, port: $port, scheme: $scheme, status: "untestable"}')
+        PROBE_FACTS=$(echo "$PROBE_FACTS" | jq --argjson f "$PROBE_FACT" '. + [$f]')
+        return 2
+    fi
+
+    local result_status="" classification=""
+    if [[ $exit_code -eq 0 && "$response" =~ ^[2-3][0-9][0-9]$ ]]; then
+        print_success "    $probe_type Probe on $scheme://$port$path: ✓ HTTP $response"
+        result_status="ok"
+        classification="success"
+    elif [[ "$response" =~ ^4[0-9][0-9]$ ]]; then
+        HAS_PROBE_ISSUES=1
+        print_error "    $probe_type Probe on $scheme://$port$path: ✗ HTTP $response - Health check endpoint not found"
+        result_status="endpoint_not_found"
+        classification="critical_4xx"
+    elif [[ "$response" =~ ^5[0-9][0-9]$ ]]; then
+        HAS_PROBE_WARNINGS=1
+        print_warning "    $probe_type Probe on $scheme://$port$path: ⚠ HTTP $response - Application error"
+        result_status="application_error"
+        classification="warning_5xx"
+    else
+        HAS_PROBE_WARNINGS=1
+        print_warning "    $probe_type Probe on $scheme://$port$path: ⚠ Connection failed (response: $response, exit code: $exit_code)"
+        result_status="connection_failed"
+        classification="warning_connection"
+    fi
+
+    PROBE_FACT=$(jq -nc --arg pod "$pod" --arg c "$container" --arg pt "$probe_type" \
+        --arg path "$path" --arg port "$port" --arg scheme "$scheme" \
+        --arg http_response "$response" --arg status "$result_status" \
+        '{pod: $pod, container: $c, probe_type: $pt, kind: "httpGet", path: $path, port: $port, scheme: $scheme, http_response: $http_response, status: $status}')
+    PROBE_FACTS=$(echo "$PROBE_FACTS" | jq --argjson f "$PROBE_FACT" '. + [$f]')
+
+    if [[ "$classification" != "success" ]]; then
+        ISSUE=$(jq -nc --arg pod "$pod" --arg c "$container" --arg pt "$probe_type" \
+            --arg path "$path" --arg port "$port" --arg http_response "$response" \
+            --arg classification "$classification" \
+            '{pod: $pod, container: $c, probe_type: $pt, path: $path, port: $port, http_response: $http_response, issue: $classification}')
+        ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+        return 1
+    fi
+    return 0
+}
+
 for POD_NAME in $PODS; do
-    # Get pod info from pre-collected data
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
 
-    # Check if pod is running
     POD_PHASE=$(echo "$POD_INFO" | jq -r '.status.phase')
     if [[ "$POD_PHASE" != "Running" ]]; then
         print_warning "Pod $POD_NAME: Not running (phase: $POD_PHASE), skipping probe checks"
+        FACT=$(jq -nc --arg p "$POD_NAME" --arg phase "$POD_PHASE" '{pod: $p, status: "skipped", reason: "not_running", phase: $phase}')
+        POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
-    # Get pod IP
     POD_IP=$(echo "$POD_INFO" | jq -r '.status.podIP')
     if [[ -z "$POD_IP" || "$POD_IP" == "null" ]]; then
         print_warning "Pod $POD_NAME: No IP assigned, skipping probe checks"
+        FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, status: "skipped", reason: "no_ip"}')
+        POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
     print_info "Checking pod $POD_NAME:"
 
-    # Get all containers
     CONTAINERS=$(echo "$POD_INFO" | jq -r '.spec.containers[] | @base64')
 
     for CONTAINER_B64 in $CONTAINERS; do
@@ -42,7 +129,6 @@ for POD_NAME in $PODS; do
 
         print_info "  Container '$CONTAINER_NAME':"
 
-        # Check container status before testing probes
         CONTAINER_STATUS=$(echo "$POD_INFO" | jq -r --arg name "$CONTAINER_NAME" '.status.containerStatuses[]? | select(.name == $name)')
 
         if [[ -z "$CONTAINER_STATUS" ]]; then
@@ -50,7 +136,6 @@ for POD_NAME in $PODS; do
             continue
         fi
 
-        # Check if container is ready
         CONTAINER_READY=$(echo "$CONTAINER_STATUS" | jq -r '.ready')
         CONTAINER_STATE=$(echo "$CONTAINER_STATUS" | jq -r '
             if .state.running then "running"
@@ -60,13 +145,11 @@ for POD_NAME in $PODS; do
             end
         ')
 
-        # If container is not running, explain why we can't test probes
         if [[ "$CONTAINER_STATE" != "running" ]]; then
             if [[ "$CONTAINER_STATE" == "waiting" ]]; then
                 WAITING_REASON=$(echo "$CONTAINER_STATUS" | jq -r '.state.waiting.reason // "Unknown"')
                 WAITING_MESSAGE=$(echo "$CONTAINER_STATUS" | jq -r '.state.waiting.message // ""')
 
-                # Check if it's a normal startup state or a problem
                 case "$WAITING_REASON" in
                     ContainerCreating|PodInitializing|Pulling)
                         CONTAINERS_SKIPPED=$((CONTAINERS_SKIPPED + 1))
@@ -101,12 +184,10 @@ for POD_NAME in $PODS; do
             fi
         fi
 
-        # Container is running - check if it's ready
         if [[ "$CONTAINER_READY" != "true" ]]; then
             print_info "    Container is running but not ready - probe checks may show why"
         fi
 
-        # Check if container has any probes configured
         HAS_READINESS=$(echo "$CONTAINER_DATA" | jq -r '.readinessProbe // empty')
         HAS_LIVENESS=$(echo "$CONTAINER_DATA" | jq -r '.livenessProbe // empty')
         HAS_STARTUP=$(echo "$CONTAINER_DATA" | jq -r '.startupProbe // empty')
@@ -116,286 +197,97 @@ for POD_NAME in $PODS; do
             continue
         fi
 
-        # Container has probes and is testable
         CONTAINERS_TESTED=$((CONTAINERS_TESTED + 1))
 
-        # Track issues for this container to avoid repetitive action messages
-        CONTAINER_HAS_CONNECTION_ISSUES=0
-        CONTAINER_HAS_4XX_ISSUES=0
-        CONTAINER_HAS_5XX_ISSUES=0
-        FAILED_PROBES_LIST=""
+        # Test each probe type that's configured
+        for PROBE_KIND in readinessProbe livenessProbe startupProbe; do
+            local_has_probe=""
+            case "$PROBE_KIND" in
+                readinessProbe) local_has_probe="$HAS_READINESS"; PROBE_LABEL="Readiness" ;;
+                livenessProbe)  local_has_probe="$HAS_LIVENESS"; PROBE_LABEL="Liveness"  ;;
+                startupProbe)   local_has_probe="$HAS_STARTUP"; PROBE_LABEL="Startup"   ;;
+            esac
 
-        # Check Readiness Probe
-        if [[ -n "$HAS_READINESS" ]]; then
-            PROBE_TYPE=$(echo "$CONTAINER_DATA" | jq -r 'if .readinessProbe.httpGet then "httpGet" elif .readinessProbe.tcpSocket then "tcpSocket" elif .readinessProbe.exec then "exec" else "unknown" end')
+            [[ -z "$local_has_probe" ]] && continue
 
-            if [[ "$PROBE_TYPE" == "httpGet" ]]; then
-                PROBE_PATH=$(echo "$CONTAINER_DATA" | jq -r '.readinessProbe.httpGet.path')
-                PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r '.readinessProbe.httpGet.port')
-                PROBE_SCHEME=$(echo "$CONTAINER_DATA" | jq -r '.readinessProbe.httpGet.scheme // "HTTP"')
-                PROBE_URL="${PROBE_SCHEME,,}://$POD_IP:$PROBE_PORT$PROBE_PATH"
-
-                # Try curl first from agent, then wget
-                if command -v curl >/dev/null 2>&1; then
-                    if [[ "${PROBE_SCHEME^^}" == "HTTPS" ]]; then
-                        PROBE_RESPONSE=$(curl -k -s -o /dev/null -w '%{http_code}' --max-time 2 "$PROBE_URL" 2>&1)
-                    else
-                        PROBE_RESPONSE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$PROBE_URL" 2>&1)
-                    fi
-                    PROBE_EXIT_CODE=$?
-                elif command -v wget >/dev/null 2>&1; then
-                    if [[ "${PROBE_SCHEME^^}" == "HTTPS" ]]; then
-                        PROBE_RESPONSE=$(wget --no-check-certificate -O /dev/null --timeout=2 "$PROBE_URL" 2>&1)
-                    else
-                        PROBE_RESPONSE=$(wget -O /dev/null --timeout=2 "$PROBE_URL" 2>&1)
-                    fi
-                    PROBE_EXIT_CODE=$?
-                    # Parse wget output to extract HTTP status or error
-                    if [[ $PROBE_EXIT_CODE -eq 0 ]]; then
-                        PROBE_RESPONSE="200"
-                    else
-                        # Extract error from wget output - try multiple patterns
-                        ERROR_MSG=$(echo "$PROBE_RESPONSE" | grep -iE "failed:|connection refused|timed? ?out|cannot connect|unable to|network|unreachable" | head -1)
-                        if [[ -n "$ERROR_MSG" ]]; then
-                            # Shorten the message if too long
-                            PROBE_RESPONSE=$(echo "$ERROR_MSG" | cut -c1-80)
-                        else
-                            # If no specific error found, show exit code
-                            PROBE_RESPONSE="wget failed with exit code $PROBE_EXIT_CODE"
-                        fi
-                    fi
-                else
-                    print_warning "    Readiness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: Cannot test (curl/wget not available in agent)"
-                    continue
-                fi
-
-                if [[ $PROBE_EXIT_CODE -eq 0 && "$PROBE_RESPONSE" =~ ^[2-3][0-9][0-9]$ ]]; then
-                    print_success "    Readiness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ✓ HTTP $PROBE_RESPONSE"
-                else
-                    # Probe failed - check if it's config issue or app issue
-                    if [[ "$PROBE_RESPONSE" =~ ^4[0-9][0-9]$ ]]; then
-                        # 4xx error: endpoint not found or bad config
-                        HAS_PROBE_ISSUES=1
-                        CONTAINER_HAS_4XX_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Readiness"
-                        print_error "    Readiness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ✗ HTTP $PROBE_RESPONSE - Health check endpoint not found"
-                    elif [[ "$PROBE_RESPONSE" =~ ^5[0-9][0-9]$ ]]; then
-                        # 5xx error: app has internal issues
-                        HAS_PROBE_WARNINGS=1
-                        CONTAINER_HAS_5XX_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Readiness"
-                        print_warning "    Readiness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ⚠ HTTP $PROBE_RESPONSE - Application error"
-                    else
-                        # Connection failed or other error (port not listening, network issue, etc)
-                        HAS_PROBE_WARNINGS=1
-                        CONTAINER_HAS_CONNECTION_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Readiness"
-                        print_warning "    Readiness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ⚠ Connection failed (response: $PROBE_RESPONSE, exit code: $PROBE_EXIT_CODE)"
-                    fi
-                fi
-            elif [[ "$PROBE_TYPE" == "tcpSocket" ]]; then
-                PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r '.readinessProbe.tcpSocket.port')
-                print_info "    Readiness Probe: TCP Socket on port $PROBE_PORT (tested in port health check)"
-            elif [[ "$PROBE_TYPE" == "exec" ]]; then
-                PROBE_COMMAND=$(echo "$CONTAINER_DATA" | jq -r '.readinessProbe.exec.command | join(" ")')
-                print_info "    Readiness Probe: Exec [$PROBE_COMMAND] (cannot test directly)"
-            fi
-        fi
-
-        # Check Liveness Probe
-        if [[ -n "$HAS_LIVENESS" ]]; then
-            PROBE_TYPE=$(echo "$CONTAINER_DATA" | jq -r 'if .livenessProbe.httpGet then "httpGet" elif .livenessProbe.tcpSocket then "tcpSocket" elif .livenessProbe.exec then "exec" else "unknown" end')
+            PROBE_TYPE=$(echo "$CONTAINER_DATA" | jq -r --arg p "$PROBE_KIND" 'if .[$p].httpGet then "httpGet" elif .[$p].tcpSocket then "tcpSocket" elif .[$p].exec then "exec" else "unknown" end')
 
             if [[ "$PROBE_TYPE" == "httpGet" ]]; then
-                PROBE_PATH=$(echo "$CONTAINER_DATA" | jq -r '.livenessProbe.httpGet.path')
-                PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r '.livenessProbe.httpGet.port')
-                PROBE_SCHEME=$(echo "$CONTAINER_DATA" | jq -r '.livenessProbe.httpGet.scheme // "HTTP"')
-                PROBE_URL="${PROBE_SCHEME,,}://$POD_IP:$PROBE_PORT$PROBE_PATH"
+                PROBE_PATH=$(echo "$CONTAINER_DATA" | jq -r --arg p "$PROBE_KIND" '.[$p].httpGet.path')
+                PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r --arg p "$PROBE_KIND" '.[$p].httpGet.port')
+                PROBE_SCHEME=$(echo "$CONTAINER_DATA" | jq -r --arg p "$PROBE_KIND" '.[$p].httpGet.scheme // "HTTP"')
 
-                # Try curl first from agent, then wget
-                if command -v curl >/dev/null 2>&1; then
-                    if [[ "${PROBE_SCHEME^^}" == "HTTPS" ]]; then
-                        PROBE_RESPONSE=$(curl -k -s -o /dev/null -w '%{http_code}' --max-time 2 "$PROBE_URL" 2>&1)
-                    else
-                        PROBE_RESPONSE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$PROBE_URL" 2>&1)
-                    fi
-                    PROBE_EXIT_CODE=$?
-                elif command -v wget >/dev/null 2>&1; then
-                    if [[ "${PROBE_SCHEME^^}" == "HTTPS" ]]; then
-                        PROBE_RESPONSE=$(wget --no-check-certificate -O /dev/null --timeout=2 "$PROBE_URL" 2>&1)
-                    else
-                        PROBE_RESPONSE=$(wget -O /dev/null --timeout=2 "$PROBE_URL" 2>&1)
-                    fi
-                    PROBE_EXIT_CODE=$?
-                    # Parse wget output to extract HTTP status or error
-                    if [[ $PROBE_EXIT_CODE -eq 0 ]]; then
-                        PROBE_RESPONSE="200"
-                    else
-                        # Extract error from wget output - try multiple patterns
-                        ERROR_MSG=$(echo "$PROBE_RESPONSE" | grep -iE "failed:|connection refused|timed? ?out|cannot connect|unable to|network|unreachable" | head -1)
-                        if [[ -n "$ERROR_MSG" ]]; then
-                            # Shorten the message if too long
-                            PROBE_RESPONSE=$(echo "$ERROR_MSG" | cut -c1-80)
-                        else
-                            # If no specific error found, show exit code
-                            PROBE_RESPONSE="wget failed with exit code $PROBE_EXIT_CODE"
-                        fi
-                    fi
-                else
-                    print_warning "    Liveness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: Cannot test (curl/wget not available in agent)"
-                    continue
-                fi
-
-                if [[ $PROBE_EXIT_CODE -eq 0 && "$PROBE_RESPONSE" =~ ^[2-3][0-9][0-9]$ ]]; then
-                    print_success "    Liveness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ✓ HTTP $PROBE_RESPONSE"
-                else
-                    # Probe failed - check if it's config issue or app issue
-                    if [[ "$PROBE_RESPONSE" =~ ^4[0-9][0-9]$ ]]; then
-                        # 4xx error: endpoint not found or bad config
-                        HAS_PROBE_ISSUES=1
-                        CONTAINER_HAS_4XX_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Liveness"
-                        print_error "    Liveness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ✗ HTTP $PROBE_RESPONSE - Health check endpoint not found"
-                    elif [[ "$PROBE_RESPONSE" =~ ^5[0-9][0-9]$ ]]; then
-                        # 5xx error: app has internal issues
-                        HAS_PROBE_WARNINGS=1
-                        CONTAINER_HAS_5XX_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Liveness"
-                        print_warning "    Liveness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ⚠ HTTP $PROBE_RESPONSE - Application error"
-                    else
-                        # Connection failed or other error (port not listening, network issue, etc)
-                        HAS_PROBE_WARNINGS=1
-                        CONTAINER_HAS_CONNECTION_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Liveness"
-                        print_warning "    Liveness Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ⚠ Connection failed (response: $PROBE_RESPONSE, exit code: $PROBE_EXIT_CODE)"
-                    fi
+                test_http_probe "$POD_NAME" "$CONTAINER_NAME" "$PROBE_LABEL" "$PROBE_PATH" "$PROBE_PORT" "$PROBE_SCHEME"
+                rc=$?
+                if [[ $rc -eq 1 ]]; then
+                    mark_affected "$POD_NAME"
                 fi
             elif [[ "$PROBE_TYPE" == "tcpSocket" ]]; then
-                PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r '.livenessProbe.tcpSocket.port')
-                print_info "    Liveness Probe: TCP Socket on port $PROBE_PORT (tested in port health check)"
+                PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r --arg p "$PROBE_KIND" '.[$p].tcpSocket.port')
+                print_info "    $PROBE_LABEL Probe: TCP Socket on port $PROBE_PORT (tested in port health check)"
+                PROBE_FACT=$(jq -nc --arg pod "$POD_NAME" --arg c "$CONTAINER_NAME" --arg pt "$PROBE_LABEL" --arg port "$PROBE_PORT" \
+                    '{pod: $pod, container: $c, probe_type: $pt, kind: "tcpSocket", port: $port, status: "not_tested_here"}')
+                PROBE_FACTS=$(echo "$PROBE_FACTS" | jq --argjson f "$PROBE_FACT" '. + [$f]')
             elif [[ "$PROBE_TYPE" == "exec" ]]; then
-                PROBE_COMMAND=$(echo "$CONTAINER_DATA" | jq -r '.livenessProbe.exec.command | join(" ")')
-                print_info "    Liveness Probe: Exec [$PROBE_COMMAND] (cannot test directly)"
+                PROBE_COMMAND=$(echo "$CONTAINER_DATA" | jq -r --arg p "$PROBE_KIND" '.[$p].exec.command | join(" ")')
+                print_info "    $PROBE_LABEL Probe: Exec [$PROBE_COMMAND] (cannot test directly)"
+                PROBE_FACT=$(jq -nc --arg pod "$POD_NAME" --arg c "$CONTAINER_NAME" --arg pt "$PROBE_LABEL" --arg cmd "$PROBE_COMMAND" \
+                    '{pod: $pod, container: $c, probe_type: $pt, kind: "exec", command: $cmd, status: "untestable"}')
+                PROBE_FACTS=$(echo "$PROBE_FACTS" | jq --argjson f "$PROBE_FACT" '. + [$f]')
             fi
-        fi
-
-        # Check Startup Probe
-        if [[ -n "$HAS_STARTUP" ]]; then
-            PROBE_TYPE=$(echo "$CONTAINER_DATA" | jq -r 'if .startupProbe.httpGet then "httpGet" elif .startupProbe.tcpSocket then "tcpSocket" elif .startupProbe.exec then "exec" else "unknown" end')
-
-            if [[ "$PROBE_TYPE" == "httpGet" ]]; then
-                PROBE_PATH=$(echo "$CONTAINER_DATA" | jq -r '.startupProbe.httpGet.path')
-                PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r '.startupProbe.httpGet.port')
-                PROBE_SCHEME=$(echo "$CONTAINER_DATA" | jq -r '.startupProbe.httpGet.scheme // "HTTP"')
-                PROBE_URL="${PROBE_SCHEME,,}://$POD_IP:$PROBE_PORT$PROBE_PATH"
-
-                # Try curl first from agent, then wget
-                if command -v curl >/dev/null 2>&1; then
-                    if [[ "${PROBE_SCHEME^^}" == "HTTPS" ]]; then
-                        PROBE_RESPONSE=$(curl -k -s -o /dev/null -w '%{http_code}' --max-time 2 "$PROBE_URL" 2>&1)
-                    else
-                        PROBE_RESPONSE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 2 "$PROBE_URL" 2>&1)
-                    fi
-                    PROBE_EXIT_CODE=$?
-                elif command -v wget >/dev/null 2>&1; then
-                    if [[ "${PROBE_SCHEME^^}" == "HTTPS" ]]; then
-                        PROBE_RESPONSE=$(wget --no-check-certificate -O /dev/null --timeout=2 "$PROBE_URL" 2>&1)
-                    else
-                        PROBE_RESPONSE=$(wget -O /dev/null --timeout=2 "$PROBE_URL" 2>&1)
-                    fi
-                    PROBE_EXIT_CODE=$?
-                    # Parse wget output to extract HTTP status or error
-                    if [[ $PROBE_EXIT_CODE -eq 0 ]]; then
-                        PROBE_RESPONSE="200"
-                    else
-                        # Extract error from wget output - try multiple patterns
-                        ERROR_MSG=$(echo "$PROBE_RESPONSE" | grep -iE "failed:|connection refused|timed? ?out|cannot connect|unable to|network|unreachable" | head -1)
-                        if [[ -n "$ERROR_MSG" ]]; then
-                            # Shorten the message if too long
-                            PROBE_RESPONSE=$(echo "$ERROR_MSG" | cut -c1-80)
-                        else
-                            # If no specific error found, show exit code
-                            PROBE_RESPONSE="wget failed with exit code $PROBE_EXIT_CODE"
-                        fi
-                    fi
-                else
-                    print_warning "    Startup Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: Cannot test (curl/wget not available in agent)"
-                    continue
-                fi
-
-                if [[ $PROBE_EXIT_CODE -eq 0 && "$PROBE_RESPONSE" =~ ^[2-3][0-9][0-9]$ ]]; then
-                    print_success "    Startup Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ✓ HTTP $PROBE_RESPONSE"
-                else
-                    # Probe failed - check if it's config issue or app issue
-                    if [[ "$PROBE_RESPONSE" =~ ^4[0-9][0-9]$ ]]; then
-                        # 4xx error: endpoint not found or bad config
-                        HAS_PROBE_ISSUES=1
-                        CONTAINER_HAS_4XX_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Startup"
-                        print_error "    Startup Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ✗ HTTP $PROBE_RESPONSE - Health check endpoint not found"
-                    elif [[ "$PROBE_RESPONSE" =~ ^5[0-9][0-9]$ ]]; then
-                        # 5xx error: app has internal issues
-                        HAS_PROBE_WARNINGS=1
-                        CONTAINER_HAS_5XX_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Startup"
-                        print_warning "    Startup Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ⚠ HTTP $PROBE_RESPONSE - Application error"
-                    else
-                        # Connection failed or other error (port not listening, network issue, etc)
-                        HAS_PROBE_WARNINGS=1
-                        CONTAINER_HAS_CONNECTION_ISSUES=1
-                        FAILED_PROBES_LIST="$FAILED_PROBES_LIST Startup"
-                        print_warning "    Startup Probe on $PROBE_SCHEME://$PROBE_PORT$PROBE_PATH: ⚠ Connection failed (response: $PROBE_RESPONSE, exit code: $PROBE_EXIT_CODE)"
-                    fi
-                fi
-            elif [[ "$PROBE_TYPE" == "tcpSocket" ]]; then
-                PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r '.startupProbe.tcpSocket.port')
-                print_info "    Startup Probe: TCP Socket on port $PROBE_PORT"
-            elif [[ "$PROBE_TYPE" == "exec" ]]; then
-                PROBE_COMMAND=$(echo "$CONTAINER_DATA" | jq -r '.startupProbe.exec.command | join(" ")')
-                print_info "    Startup Probe: Exec [$PROBE_COMMAND] (cannot test directly)"
-            fi
-        fi
-
-        # Print consolidated action message for this container (avoid repetition)
-        if [[ -n "$FAILED_PROBES_LIST" ]]; then
-            echo ""
-            # Trim leading space from the list
-            FAILED_PROBES_LIST=$(echo "$FAILED_PROBES_LIST" | xargs)
-
-            if [[ $CONTAINER_HAS_CONNECTION_ISSUES -eq 1 ]]; then
-                print_action "For $FAILED_PROBES_LIST probe(s): Verify port is listening and accessible from within cluster"
-            fi
-
-            if [[ $CONTAINER_HAS_4XX_ISSUES -eq 1 ]]; then
-                print_action "For $FAILED_PROBES_LIST probe(s): Update probe path or implement the endpoint in application"
-            fi
-
-            if [[ $CONTAINER_HAS_5XX_ISSUES -eq 1 ]]; then
-                print_action "For $FAILED_PROBES_LIST probe(s): Check application logs and fix internal errors or dependencies"
-            fi
-        fi
+        done
     done
 done
 
 echo ""
+
+DETAILS=$(jq -nc \
+    --argjson tested "$CONTAINERS_TESTED" \
+    --argjson skipped "$CONTAINERS_SKIPPED" \
+    --argjson probes "$PROBE_FACTS" \
+    --argjson issues "$ISSUE_FACTS" \
+    '{
+        containers_tested: $tested,
+        containers_skipped: $skipped,
+        probe_results: $probes,
+        issue_count: ($issues | length),
+        issues: $issues
+    }')
+
 if [[ $CONTAINERS_TESTED -eq 0 ]]; then
-    # No containers were tested - all were skipped
     print_info "All containers skipped - no probe checks could be performed"
-    update_check_result --status "skipped" --evidence "{\"tested\":$CONTAINERS_TESTED,\"skipped\":$CONTAINERS_SKIPPED}"
+    EVIDENCE=$(evidence_json \
+        "All containers skipped — no probe checks performed" \
+        "info" \
+        "[]" \
+        "$DETAILS" \
+        "[]")
+    update_check_result --status "skipped" --evidence "$EVIDENCE"
 elif [[ $HAS_PROBE_ISSUES -gt 0 ]]; then
-    # Some containers were tested and had issues
     if [[ $CONTAINERS_SKIPPED -gt 0 ]]; then
         print_warning "Probe issues found ($CONTAINERS_TESTED tested, $CONTAINERS_SKIPPED skipped)"
     fi
-    update_check_result --status "failed" --evidence "{\"tested\":$CONTAINERS_TESTED,\"skipped\":$CONTAINERS_SKIPPED}"
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    SUMMARY="Probe failures detected in $AFFECTED_COUNT pod(s)"
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+        '["Update probe path or implement health endpoint in application", "Verify port is listening and accessible"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 elif [[ $HAS_PROBE_WARNINGS -gt 0 ]]; then
-    # Some containers were tested and had warnings
     if [[ $CONTAINERS_SKIPPED -gt 0 ]]; then
         print_info "Probe warnings found ($CONTAINERS_TESTED tested, $CONTAINERS_SKIPPED skipped)"
     fi
-    update_check_result --status "warning" --evidence "{\"tested\":$CONTAINERS_TESTED,\"skipped\":$CONTAINERS_SKIPPED}"
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    SUMMARY="Probe warnings in $AFFECTED_COUNT pod(s) — application or connectivity issues"
+    EVIDENCE=$(evidence_json "$SUMMARY" "warning" "$AFFECTED_PODS" "$DETAILS" \
+        '["Check application logs for internal errors", "Verify port is listening and accessible"]')
+    update_check_result --status "warning" --evidence "$EVIDENCE"
 else
-    # All tested containers passed
     print_success "Health probes verified on $CONTAINERS_TESTED container(s)"
-    update_check_result --status "success" --evidence "{\"tested\":$CONTAINERS_TESTED,\"skipped\":$CONTAINERS_SKIPPED}"
+    EVIDENCE=$(evidence_json \
+        "Health probes verified on $CONTAINERS_TESTED container(s)" \
+        "info" \
+        "[]" \
+        "$DETAILS" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/health_probe_endpoints
+++ b/k8s/diagnose/scope/health_probe_endpoints
@@ -11,14 +11,11 @@ HAS_PROBE_WARNINGS=0
 CONTAINERS_TESTED=0
 CONTAINERS_SKIPPED=0
 
-PROBE_FACTS="[]"
-ISSUE_FACTS="[]"
-POD_FACTS="[]"
-AFFECTED_PODS="[]"
+PROBE_FACTS=()
+ISSUE_FACTS=()
+POD_FACTS=()
+AFFECTED_PODS=""
 
-mark_affected() {
-    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
-}
 
 # Probe a single HTTP endpoint and emit a JSON fact + classification
 # Args: pod, container, probe_type (Readiness/Liveness/Startup), path, port, scheme
@@ -57,7 +54,7 @@ test_http_probe() {
         PROBE_FACT=$(jq -nc --arg pod "$pod" --arg c "$container" --arg pt "$probe_type" \
             --arg path "$path" --arg port "$port" --arg scheme "$scheme" \
             '{pod: $pod, container: $c, probe_type: $pt, kind: "httpGet", path: $path, port: $port, scheme: $scheme, status: "untestable"}')
-        PROBE_FACTS=$(echo "$PROBE_FACTS" | jq --argjson f "$PROBE_FACT" '. + [$f]')
+        add_fact PROBE_FACTS "$PROBE_FACT"
         return 2
     fi
 
@@ -95,7 +92,7 @@ test_http_probe() {
         --arg path "$path" --arg port "$port" --arg scheme "$scheme" \
         --arg http_response "$response" --arg status "$result_status" \
         '{pod: $pod, container: $c, probe_type: $pt, kind: "httpGet", path: $path, port: $port, scheme: $scheme, http_response: $http_response, status: $status}')
-    PROBE_FACTS=$(echo "$PROBE_FACTS" | jq --argjson f "$PROBE_FACT" '. + [$f]')
+    add_fact PROBE_FACTS "$PROBE_FACT"
 
     if [[ "$classification" != "success" ]]; then
         ISSUE=$(jq -nc --arg pod "$pod" --arg c "$container" --arg pt "$probe_type" \
@@ -103,7 +100,7 @@ test_http_probe() {
             --arg classification "$classification" \
             --argjson logs "$container_logs" \
             '{pod: $pod, container: $c, probe_type: $pt, path: $path, port: $port, http_response: $http_response, issue: $classification, container_logs: $logs}')
-        ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$ISSUE" '. + [$f]')
+        add_fact ISSUE_FACTS "$ISSUE"
         return 1
     fi
     return 0
@@ -116,7 +113,7 @@ for POD_NAME in $PODS; do
     if [[ "$POD_PHASE" != "Running" ]]; then
         print_warning "Pod $POD_NAME: Not running (phase: $POD_PHASE), skipping probe checks"
         FACT=$(jq -nc --arg p "$POD_NAME" --arg phase "$POD_PHASE" '{pod: $p, status: "skipped", reason: "not_running", phase: $phase}')
-        POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact POD_FACTS "$FACT"
         continue
     fi
 
@@ -124,7 +121,7 @@ for POD_NAME in $PODS; do
     if [[ -z "$POD_IP" || "$POD_IP" == "null" ]]; then
         print_warning "Pod $POD_NAME: No IP assigned, skipping probe checks"
         FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, status: "skipped", reason: "no_ip"}')
-        POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact POD_FACTS "$FACT"
         continue
     fi
 
@@ -229,20 +226,20 @@ for POD_NAME in $PODS; do
                 test_http_probe "$POD_NAME" "$CONTAINER_NAME" "$PROBE_LABEL" "$PROBE_PATH" "$PROBE_PORT" "$PROBE_SCHEME"
                 rc=$?
                 if [[ $rc -eq 1 ]]; then
-                    mark_affected "$POD_NAME"
+                    mark_affected AFFECTED_PODS "$POD_NAME"
                 fi
             elif [[ "$PROBE_TYPE" == "tcpSocket" ]]; then
                 PROBE_PORT=$(echo "$CONTAINER_DATA" | jq -r --arg p "$PROBE_KIND" '.[$p].tcpSocket.port')
                 print_info "    $PROBE_LABEL Probe: TCP Socket on port $PROBE_PORT (tested in port health check)"
                 PROBE_FACT=$(jq -nc --arg pod "$POD_NAME" --arg c "$CONTAINER_NAME" --arg pt "$PROBE_LABEL" --arg port "$PROBE_PORT" \
                     '{pod: $pod, container: $c, probe_type: $pt, kind: "tcpSocket", port: $port, status: "not_tested_here"}')
-                PROBE_FACTS=$(echo "$PROBE_FACTS" | jq --argjson f "$PROBE_FACT" '. + [$f]')
+                add_fact PROBE_FACTS "$PROBE_FACT"
             elif [[ "$PROBE_TYPE" == "exec" ]]; then
                 PROBE_COMMAND=$(echo "$CONTAINER_DATA" | jq -r --arg p "$PROBE_KIND" '.[$p].exec.command | join(" ")')
                 print_info "    $PROBE_LABEL Probe: Exec [$PROBE_COMMAND] (cannot test directly)"
                 PROBE_FACT=$(jq -nc --arg pod "$POD_NAME" --arg c "$CONTAINER_NAME" --arg pt "$PROBE_LABEL" --arg cmd "$PROBE_COMMAND" \
                     '{pod: $pod, container: $c, probe_type: $pt, kind: "exec", command: $cmd, status: "untestable"}')
-                PROBE_FACTS=$(echo "$PROBE_FACTS" | jq --argjson f "$PROBE_FACT" '. + [$f]')
+                add_fact PROBE_FACTS "$PROBE_FACT"
             fi
         done
     done
@@ -253,8 +250,8 @@ echo ""
 DETAILS=$(jq -nc \
     --argjson tested "$CONTAINERS_TESTED" \
     --argjson skipped "$CONTAINERS_SKIPPED" \
-    --argjson probes "$PROBE_FACTS" \
-    --argjson issues "$ISSUE_FACTS" \
+    --argjson probes "$(facts_to_json_array PROBE_FACTS)" \
+    --argjson issues "$(facts_to_json_array ISSUE_FACTS)" \
     '{
         containers_tested: $tested,
         containers_skipped: $skipped,
@@ -276,18 +273,18 @@ elif [[ $HAS_PROBE_ISSUES -gt 0 ]]; then
     if [[ $CONTAINERS_SKIPPED -gt 0 ]]; then
         print_warning "Probe issues found ($CONTAINERS_TESTED tested, $CONTAINERS_SKIPPED skipped)"
     fi
-    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | wc -w | tr -d ' ')
     SUMMARY="Probe failures detected in $AFFECTED_COUNT pod(s)"
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_PODS)" "$DETAILS" \
         '["Update probe path or implement health endpoint in application", "Verify port is listening and accessible"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 elif [[ $HAS_PROBE_WARNINGS -gt 0 ]]; then
     if [[ $CONTAINERS_SKIPPED -gt 0 ]]; then
         print_info "Probe warnings found ($CONTAINERS_TESTED tested, $CONTAINERS_SKIPPED skipped)"
     fi
-    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | wc -w | tr -d ' ')
     SUMMARY="Probe warnings in $AFFECTED_COUNT pod(s) — application or connectivity issues"
-    EVIDENCE=$(evidence_json "$SUMMARY" "warning" "$AFFECTED_PODS" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "warning" "$(set_to_json_array AFFECTED_PODS)" "$DETAILS" \
         '["Check application logs for internal errors", "Verify port is listening and accessible"]')
     update_check_result --status "warning" --evidence "$EVIDENCE"
 else

--- a/k8s/diagnose/scope/image_pull_status
+++ b/k8s/diagnose/scope/image_pull_status
@@ -2,38 +2,66 @@
 # Check: Image Pull Status
 # Verifies container images can be pulled from registry
 
-# Validate pods exist
 require_pods || return 0
 
-# Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ERRORS=0
+PULL_FAILURES="[]"
+AFFECTED_PODS="[]"
+
+mark_affected() {
+    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
+}
 
 for POD_NAME in $PODS; do
-      # Get pod info from pre-collected data
       POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
 
       IMAGE_PULL_ERRORS=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.state.waiting.reason == "ImagePullBackOff" or .state.waiting.reason == "ErrImagePull") | .name')
 
       if [[ -n "$IMAGE_PULL_ERRORS" ]]; then
-          HAS_ERRORS=1
+          mark_affected "$POD_NAME"
           print_error "Pod $POD_NAME: ImagePullBackOff/ErrImagePull in container(s): $IMAGE_PULL_ERRORS"
 
           for CONTAINER in $IMAGE_PULL_ERRORS; do
               IMAGE=$(echo "$POD_INFO" | jq -r ".spec.containers[] | select(.name==\"$CONTAINER\") | .image")
-              MESSAGE=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .state.waiting.message")
+              MESSAGE=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .state.waiting.message // \"\"")
+              REASON=$(echo "$POD_INFO" | jq -r ".status.containerStatuses[] | select(.name==\"$CONTAINER\") | .state.waiting.reason // \"\"")
               print_warning "  Image: $IMAGE"
               print_warning "  Reason: $MESSAGE"
+
+              FACT=$(jq -nc \
+                  --arg pod "$POD_NAME" \
+                  --arg container "$CONTAINER" \
+                  --arg image "$IMAGE" \
+                  --arg reason "$REASON" \
+                  --arg message "$MESSAGE" \
+                  '{pod: $pod, container: $container, image: $image, reason: $reason, message: $message}')
+              PULL_FAILURES=$(echo "$PULL_FAILURES" | jq --argjson f "$FACT" '. + [$f]')
           done
           print_action "Verify image exists and imagePullSecrets are configured for private registries"
       fi
 done
 
-if [[ $HAS_ERRORS -eq 0 ]]; then
-    POD_COUNT=$(echo "$PODS" | wc -w)
+POD_COUNT=$(echo "$PODS" | wc -w | tr -d ' ')
+FAIL_COUNT=$(echo "$PULL_FAILURES" | jq 'length')
+
+if [[ $FAIL_COUNT -eq 0 ]]; then
     print_success "All $POD_COUNT pod(s) have images pulled successfully"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "All $POD_COUNT pod(s) have images pulled successfully" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson count "$POD_COUNT" '{pods_checked: $count}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) failing to pull images"
+    DETAILS=$(jq -nc \
+        --argjson failures "$PULL_FAILURES" \
+        --argjson pod_count "$POD_COUNT" \
+        '{pod_count: $pod_count, failure_count: ($failures | length), failures: $failures}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+        '["Verify image exists and imagePullSecrets are configured for private registries"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/image_pull_status
+++ b/k8s/diagnose/scope/image_pull_status
@@ -6,12 +6,9 @@ require_pods || return 0
 
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-PULL_FAILURES="[]"
-AFFECTED_PODS="[]"
+PULL_FAILURES=()
+AFFECTED_PODS=""
 
-mark_affected() {
-    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
-}
 
 for POD_NAME in $PODS; do
       POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
@@ -19,7 +16,7 @@ for POD_NAME in $PODS; do
       IMAGE_PULL_ERRORS=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.state.waiting.reason == "ImagePullBackOff" or .state.waiting.reason == "ErrImagePull") | .name')
 
       if [[ -n "$IMAGE_PULL_ERRORS" ]]; then
-          mark_affected "$POD_NAME"
+          mark_affected AFFECTED_PODS "$POD_NAME"
           print_error "Pod $POD_NAME: ImagePullBackOff/ErrImagePull in container(s): $IMAGE_PULL_ERRORS"
 
           for CONTAINER in $IMAGE_PULL_ERRORS; do
@@ -36,7 +33,7 @@ for POD_NAME in $PODS; do
                   --arg reason "$REASON" \
                   --arg message "$MESSAGE" \
                   '{pod: $pod, container: $container, image: $image, reason: $reason, message: $message}')
-              PULL_FAILURES=$(echo "$PULL_FAILURES" | jq --argjson f "$FACT" '. + [$f]')
+              add_fact PULL_FAILURES "$FACT"
           done
           print_action "Verify image exists and imagePullSecrets are configured for private registries"
       fi
@@ -55,13 +52,13 @@ if [[ $FAIL_COUNT -eq 0 ]]; then
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | wc -w | tr -d ' ')
     SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) failing to pull images"
     DETAILS=$(jq -nc \
-        --argjson failures "$PULL_FAILURES" \
+        --argjson failures "$(facts_to_json_array PULL_FAILURES)" \
         --argjson pod_count "$POD_COUNT" \
         '{pod_count: $pod_count, failure_count: ($failures | length), failures: $failures}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_PODS)" "$DETAILS" \
         '["Verify image exists and imagePullSecrets are configured for private registries"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/memory_limits_check
+++ b/k8s/diagnose/scope/memory_limits_check
@@ -6,12 +6,9 @@ require_pods || return 0
 
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-OOM_FACTS="[]"
-AFFECTED_PODS="[]"
+OOM_FACTS=()
+AFFECTED_PODS=""
 
-mark_affected() {
-    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
-}
 
 for POD_NAME in $PODS; do
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
@@ -19,7 +16,7 @@ for POD_NAME in $PODS; do
     OOM_KILLED=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.lastState.terminated.reason == "OOMKilled") | .name')
 
     if [[ -n "$OOM_KILLED" ]]; then
-        mark_affected "$POD_NAME"
+        mark_affected AFFECTED_PODS "$POD_NAME"
         print_error "Pod $POD_NAME: OOMKilled in container(s): $OOM_KILLED"
 
         for CONTAINER in $OOM_KILLED; do
@@ -49,7 +46,7 @@ for POD_NAME in $PODS; do
                     memory_request: $memory_request,
                     previous_logs: $previous_logs
                 }')
-            OOM_FACTS=$(echo "$OOM_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+            add_fact OOM_FACTS "$FACT"
         done
     fi
 done
@@ -67,13 +64,13 @@ if [[ $OOM_COUNT -eq 0 ]]; then
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | wc -w | tr -d ' ')
     SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) had OOMKilled containers"
     DETAILS=$(jq -nc \
-        --argjson oom "$OOM_FACTS" \
+        --argjson oom "$(facts_to_json_array OOM_FACTS)" \
         --argjson pod_count "$POD_COUNT" \
         '{pod_count: $pod_count, oom_killed_count: ($oom | length), oom_killed: $oom}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_PODS)" "$DETAILS" \
         '["Increase memory limits or optimize application memory usage"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/memory_limits_check
+++ b/k8s/diagnose/scope/memory_limits_check
@@ -31,12 +31,24 @@ for POD_NAME in $PODS; do
             print_warning "  Memory Request: $MEMORY_REQUEST"
             print_action "Increase memory limits or optimize application memory usage"
 
+            # When OOM kills a container, the previous-instance logs are where
+            # the last application output lives — the current instance was
+            # restarted by the kubelet after the kill.
+            PREVIOUS_LOGS=$(read_log_tail "$POD_NAME" "$CONTAINER" "previous")
+
             FACT=$(jq -nc \
                 --arg pod "$POD_NAME" \
                 --arg container "$CONTAINER" \
                 --arg memory_limit "$MEMORY_LIMIT" \
                 --arg memory_request "$MEMORY_REQUEST" \
-                '{pod: $pod, container: $container, memory_limit: $memory_limit, memory_request: $memory_request}')
+                --argjson previous_logs "$PREVIOUS_LOGS" \
+                '{
+                    pod: $pod,
+                    container: $container,
+                    memory_limit: $memory_limit,
+                    memory_request: $memory_request,
+                    previous_logs: $previous_logs
+                }')
             OOM_FACTS=$(echo "$OOM_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         done
     fi

--- a/k8s/diagnose/scope/memory_limits_check
+++ b/k8s/diagnose/scope/memory_limits_check
@@ -2,22 +2,24 @@
 # Check: Memory Limits
 # Checks for out-of-memory container terminations
 
-# Validate pods exist
 require_pods || return 0
 
-# Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_OOM=0
+OOM_FACTS="[]"
+AFFECTED_PODS="[]"
+
+mark_affected() {
+    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
+}
 
 for POD_NAME in $PODS; do
-    # Get pod info from pre-collected data
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
 
     OOM_KILLED=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.lastState.terminated.reason == "OOMKilled") | .name')
 
     if [[ -n "$OOM_KILLED" ]]; then
-        HAS_OOM=1
+        mark_affected "$POD_NAME"
         print_error "Pod $POD_NAME: OOMKilled in container(s): $OOM_KILLED"
 
         for CONTAINER in $OOM_KILLED; do
@@ -28,14 +30,38 @@ for POD_NAME in $PODS; do
             print_warning "  Memory Limit: $MEMORY_LIMIT"
             print_warning "  Memory Request: $MEMORY_REQUEST"
             print_action "Increase memory limits or optimize application memory usage"
+
+            FACT=$(jq -nc \
+                --arg pod "$POD_NAME" \
+                --arg container "$CONTAINER" \
+                --arg memory_limit "$MEMORY_LIMIT" \
+                --arg memory_request "$MEMORY_REQUEST" \
+                '{pod: $pod, container: $container, memory_limit: $memory_limit, memory_request: $memory_request}')
+            OOM_FACTS=$(echo "$OOM_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         done
     fi
 done
 
-if [[ $HAS_OOM -eq 0 ]]; then
-    POD_COUNT=$(echo "$PODS" | wc -w)
+POD_COUNT=$(echo "$PODS" | wc -w | tr -d ' ')
+OOM_COUNT=$(echo "$OOM_FACTS" | jq 'length')
+
+if [[ $OOM_COUNT -eq 0 ]]; then
     print_success "No OOMKilled containers detected in $POD_COUNT pod(s)"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "No OOMKilled containers detected in $POD_COUNT pod(s)" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson count "$POD_COUNT" '{pods_checked: $count}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) had OOMKilled containers"
+    DETAILS=$(jq -nc \
+        --argjson oom "$OOM_FACTS" \
+        --argjson pod_count "$POD_COUNT" \
+        '{pod_count: $pod_count, oom_killed_count: ($oom | length), oom_killed: $oom}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+        '["Increase memory limits or optimize application memory usage"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/pod_existence
+++ b/k8s/diagnose/scope/pod_existence
@@ -7,10 +7,26 @@ PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 if [[ -z "$PODS" ]]; then
     print_error "No pods found with labels $LABEL_SELECTOR in namespace $NAMESPACE"
     print_action "Check deployment status and verify label selectors match"
-    update_check_result --status "failed" --evidence "{}"
+
+    EVIDENCE=$(evidence_json \
+        "No pods found in namespace $NAMESPACE" \
+        "critical" \
+        "[]" \
+        "$(jq -nc --arg ls "$LABEL_SELECTOR" --arg ns "$NAMESPACE" '{label_selector: $ls, namespace: $ns}')" \
+        '["Check deployment status and verify label selectors match"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
     return 1
 fi
 
-PODS_COUNT=$(echo "$PODS" | wc -w)
+POD_NAMES_JSON=$(jq -c '[.items[].metadata.name]' "$PODS_FILE" 2>/dev/null)
+PODS_COUNT=$(echo "$PODS" | wc -w | tr -d ' ')
 print_success "Found $PODS_COUNT pod(s): $PODS"
-update_check_result --status "success" --evidence "{}"
+
+EVIDENCE=$(evidence_json \
+    "Found $PODS_COUNT pod(s) in namespace $NAMESPACE" \
+    "info" \
+    "[]" \
+    "$(jq -nc --argjson count "$PODS_COUNT" --argjson names "$POD_NAMES_JSON" --arg ns "$NAMESPACE" \
+        '{pod_count: $count, pod_names: $names, namespace: $ns}')" \
+    "[]")
+update_check_result --status "success" --evidence "$EVIDENCE"

--- a/k8s/diagnose/scope/pod_readiness
+++ b/k8s/diagnose/scope/pod_readiness
@@ -2,10 +2,8 @@
 # Check: Pod Readiness
 # Confirms pod is running and ready to serve traffic
 
-# Validate pods exist
 require_pods || return 0
 
-# Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
 # Counters for summary
@@ -16,46 +14,52 @@ NOT_READY_PODS=0
 TERMINATING_PODS=0
 STARTING_PODS=0
 
-# Deployment state detection
 HAS_TERMINATING_PODS=0
 HAS_STARTING_PODS=0
+
+POD_FACTS="[]"
+AFFECTED_PODS="[]"
+
+mark_affected() {
+    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
+}
 
 for POD_NAME in $PODS; do
       TOTAL_PODS=$((TOTAL_PODS + 1))
 
-      # Get pod info from pre-collected data
       POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
       POD_PHASE=$(echo "$POD_INFO" | jq -r '.status.phase')
-      POD_READY=$(echo "$POD_INFO" | jq -r '.status.conditions[] | select(.type=="Ready") | .status')
+      POD_READY=$(echo "$POD_INFO" | jq -r '.status.conditions[]? | select(.type=="Ready") | .status')
 
-      # Check if pod is terminating
       DELETION_TIMESTAMP=$(echo "$POD_INFO" | jq -r '.metadata.deletionTimestamp // empty')
       if [[ -n "$DELETION_TIMESTAMP" ]]; then
           TERMINATING_PODS=$((TERMINATING_PODS + 1))
           HAS_TERMINATING_PODS=1
           print_info "Pod $POD_NAME: Terminating (rollout in progress)"
+          FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, state: "terminating"}')
+          POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
           continue
       fi
 
       if [[ "$POD_PHASE" == "Running" && "$POD_READY" == "True" ]]; then
           READY_PODS=$((READY_PODS + 1))
           print_success "Pod $POD_NAME: Running and Ready"
+          FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, state: "ready", phase: "Running"}')
+          POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
       elif [[ "$POD_PHASE" == "Succeeded" ]]; then
           SUCCEEDED_PODS=$((SUCCEEDED_PODS + 1))
           print_success "Pod $POD_NAME: Completed successfully"
+          FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, state: "succeeded", phase: "Succeeded"}')
+          POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
       else
           NOT_READY_PODS=$((NOT_READY_PODS + 1))
-
-          # Detect if pod is in normal startup state and collect reasons
           IS_STARTING=0
           STARTUP_INFO=""
 
-          # Check if pod is in Pending phase (normal during startup)
           if [[ "$POD_PHASE" == "Pending" ]]; then
               IS_STARTING=1
           fi
 
-          # Check init containers first
           INIT_CONTAINER_INFO=$(echo "$POD_INFO" | jq -r '
               .status.initContainerStatuses[]? |
               select(.state.waiting or .state.running) |
@@ -71,7 +75,6 @@ for POD_NAME in $PODS; do
               STARTUP_INFO="Init: $(echo "$INIT_CONTAINER_INFO" | paste -sd ',' - | sed 's/,/, /g')"
           fi
 
-          # Check for normal container startup reasons with details
           CONTAINER_STARTUP_INFO=$(echo "$POD_INFO" | jq -r '
               .status.containerStatuses[]? |
               select(.state.waiting) |
@@ -79,7 +82,6 @@ for POD_NAME in $PODS; do
           ' 2>/dev/null)
 
           if [[ -n "$CONTAINER_STARTUP_INFO" ]]; then
-              # Check if any are normal startup reasons
               while IFS= read -r CONTAINER_LINE; do
                   REASON=$(echo "$CONTAINER_LINE" | cut -d':' -f2 | xargs)
                   case "$REASON" in
@@ -97,32 +99,32 @@ for POD_NAME in $PODS; do
               fi
           fi
 
+          POD_STATE="not_ready"
           if [[ $IS_STARTING -eq 1 ]]; then
               STARTING_PODS=$((STARTING_PODS + 1))
               HAS_STARTING_PODS=1
+              POD_STATE="starting"
               if [[ -n "$STARTUP_INFO" ]]; then
                   print_info "Pod $POD_NAME: Starting up - $STARTUP_INFO"
               else
                   print_info "Pod $POD_NAME: Phase=$POD_PHASE (starting up)"
               fi
           else
+              mark_affected "$POD_NAME"
               print_warning "Pod $POD_NAME: Phase=$POD_PHASE, Ready=$POD_READY"
           fi
 
-          # Get detailed condition information
-          READY_CONDITION=$(echo "$POD_INFO" | jq -r '.status.conditions[] | select(.type=="Ready")')
+          READY_CONDITION=$(echo "$POD_INFO" | jq -c '.status.conditions[]? | select(.type=="Ready")' | head -1)
           READY_REASON=$(echo "$READY_CONDITION" | jq -r '.reason // "Unknown"')
           READY_MESSAGE=$(echo "$READY_CONDITION" | jq -r '.message // "No message available"')
 
           if [[ -n "$READY_REASON" && "$READY_REASON" != "Unknown" ]]; then
               print_warning "  Reason: $READY_REASON"
           fi
-
           if [[ -n "$READY_MESSAGE" && "$READY_MESSAGE" != "No message available" ]]; then
               print_warning "  Message: $READY_MESSAGE"
           fi
 
-          # Check container statuses
           CONTAINER_STATUSES=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | "\(.name): Ready=\(.ready), Restarts=\(.restartCount)"' 2>/dev/null)
 
           if [[ -n "$CONTAINER_STATUSES" ]]; then
@@ -132,7 +134,6 @@ for POD_NAME in $PODS; do
               done <<< "$CONTAINER_STATUSES"
           fi
 
-          # Check for waiting containers with reasons
           WAITING_CONTAINERS=$(echo "$POD_INFO" | jq -r '.status.containerStatuses[]? | select(.state.waiting) | "  \(.name): \(.state.waiting.reason) - \(.state.waiting.message // "No details")"' 2>/dev/null)
 
           if [[ -n "$WAITING_CONTAINERS" ]]; then
@@ -142,31 +143,77 @@ for POD_NAME in $PODS; do
               done
           fi
 
-          # Only show action if not in normal startup state
           if [[ $IS_STARTING -eq 0 ]]; then
               print_action "Check application health endpoint and ensure dependencies are available"
           fi
+
+          FACT=$(jq -nc --arg p "$POD_NAME" --arg state "$POD_STATE" --arg phase "$POD_PHASE" --arg ready "$POD_READY" \
+              --arg reason "$READY_REASON" --arg message "$READY_MESSAGE" --arg startup "$STARTUP_INFO" \
+              '{pod: $p, state: $state, phase: $phase, ready: $ready, reason: $reason, message: $message, startup_info: $startup}')
+          POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
       fi
 done
 
-# Print summary
 echo ""
+
+DETAILS_BASE=$(jq -nc \
+    --argjson total "$TOTAL_PODS" \
+    --argjson ready "$READY_PODS" \
+    --argjson succeeded "$SUCCEEDED_PODS" \
+    --argjson not_ready "$NOT_READY_PODS" \
+    --argjson terminating "$TERMINATING_PODS" \
+    --argjson starting "$STARTING_PODS" \
+    --argjson facts "$POD_FACTS" \
+    '{
+        total: $total,
+        ready: $ready,
+        succeeded: $succeeded,
+        not_ready: $not_ready,
+        terminating: $terminating,
+        starting: $starting,
+        pods: $facts
+    }')
+
 if [[ $TOTAL_PODS -eq 0 ]]; then
     print_warning "No pods found"
-    update_check_result --status "failed" --evidence "{\"ready\":0,\"total\":0}"
+    EVIDENCE=$(evidence_json "No pods found" "critical" "[]" "$DETAILS_BASE" '["Check deployment and label selectors"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 elif [[ $READY_PODS -eq $TOTAL_PODS ]] || [[ $((READY_PODS + SUCCEEDED_PODS)) -eq $TOTAL_PODS ]]; then
     print_success "All pods ready: $READY_PODS/$TOTAL_PODS running and ready"
-    update_check_result --status "success" --evidence "{\"ready\":$READY_PODS,\"total\":$TOTAL_PODS}"
+    EVIDENCE=$(evidence_json \
+        "All $TOTAL_PODS pod(s) ready ($READY_PODS running, $SUCCEEDED_PODS succeeded)" \
+        "info" \
+        "[]" \
+        "$DETAILS_BASE" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 elif [[ $HAS_TERMINATING_PODS -eq 1 ]]; then
-    # Pods are terminating - deployment/rollout in progress
     print_info "Deployment in progress: $READY_PODS/$TOTAL_PODS pods ready (rollout in progress with terminating pods)"
-    update_check_result --status "warning" --evidence "{\"ready\":$READY_PODS,\"total\":$TOTAL_PODS,\"terminating\":$TERMINATING_PODS,\"deployment_in_progress\":true}"
+    DETAILS=$(echo "$DETAILS_BASE" | jq '. + {deployment_in_progress: true}')
+    EVIDENCE=$(evidence_json \
+        "Deployment in progress: $READY_PODS/$TOTAL_PODS pods ready, $TERMINATING_PODS terminating" \
+        "warning" \
+        "[]" \
+        "$DETAILS" \
+        '["Wait for rollout to complete"]')
+    update_check_result --status "warning" --evidence "$EVIDENCE"
 elif [[ $HAS_STARTING_PODS -eq 1 ]]; then
-    # Pods are starting up normally - new deployment in progress
     print_info "Deployment in progress: $READY_PODS/$TOTAL_PODS pods ready, $STARTING_PODS starting up"
-    update_check_result --status "warning" --evidence "{\"ready\":$READY_PODS,\"total\":$TOTAL_PODS,\"starting\":$STARTING_PODS,\"not_ready\":$NOT_READY_PODS,\"deployment_in_progress\":true}"
+    DETAILS=$(echo "$DETAILS_BASE" | jq '. + {deployment_in_progress: true}')
+    EVIDENCE=$(evidence_json \
+        "Deployment in progress: $READY_PODS/$TOTAL_PODS pods ready, $STARTING_PODS starting" \
+        "warning" \
+        "[]" \
+        "$DETAILS" \
+        '["Wait for pods to finish starting"]')
+    update_check_result --status "warning" --evidence "$EVIDENCE"
 else
-    # Some pods not ready and no clear sign of deployment in progress - this is a problem
     print_error "Pods not ready: $READY_PODS/$TOTAL_PODS ready (pods have issues)"
-    update_check_result --status "failed" --evidence "{\"ready\":$READY_PODS,\"total\":$TOTAL_PODS}"
+    EVIDENCE=$(evidence_json \
+        "$READY_PODS/$TOTAL_PODS pods ready — $NOT_READY_PODS pod(s) have issues" \
+        "critical" \
+        "$AFFECTED_PODS" \
+        "$DETAILS_BASE" \
+        '["Check application health endpoint and ensure dependencies are available"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/pod_readiness
+++ b/k8s/diagnose/scope/pod_readiness
@@ -147,9 +147,25 @@ for POD_NAME in $PODS; do
               print_action "Check application health endpoint and ensure dependencies are available"
           fi
 
+          # For pods stuck in "not_ready" (not just starting), embed current
+          # logs of the first container so the AI can correlate readiness
+          # failure with what the app printed. We skip starting pods because
+          # their logs are still in flight and not informative yet.
+          POD_LOGS_PER_CONTAINER="[]"
+          if [[ "$POD_STATE" == "not_ready" ]]; then
+              # Iterate first regular container only — keep payload bounded
+              FIRST_CONTAINER=$(echo "$POD_INFO" | jq -r '.spec.containers[0].name // empty')
+              if [[ -n "$FIRST_CONTAINER" ]]; then
+                  CURRENT_LOGS=$(read_log_tail "$POD_NAME" "$FIRST_CONTAINER" "current")
+                  POD_LOGS_PER_CONTAINER=$(jq -nc --arg c "$FIRST_CONTAINER" --argjson logs "$CURRENT_LOGS" \
+                      '[{container: $c, current_logs: $logs}]')
+              fi
+          fi
+
           FACT=$(jq -nc --arg p "$POD_NAME" --arg state "$POD_STATE" --arg phase "$POD_PHASE" --arg ready "$POD_READY" \
               --arg reason "$READY_REASON" --arg message "$READY_MESSAGE" --arg startup "$STARTUP_INFO" \
-              '{pod: $p, state: $state, phase: $phase, ready: $ready, reason: $reason, message: $message, startup_info: $startup}')
+              --argjson container_logs "$POD_LOGS_PER_CONTAINER" \
+              '{pod: $p, state: $state, phase: $phase, ready: $ready, reason: $reason, message: $message, startup_info: $startup, container_logs: $container_logs}')
           POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
       fi
 done

--- a/k8s/diagnose/scope/pod_readiness
+++ b/k8s/diagnose/scope/pod_readiness
@@ -17,12 +17,9 @@ STARTING_PODS=0
 HAS_TERMINATING_PODS=0
 HAS_STARTING_PODS=0
 
-POD_FACTS="[]"
-AFFECTED_PODS="[]"
+POD_FACTS=()
+AFFECTED_PODS=""
 
-mark_affected() {
-    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
-}
 
 for POD_NAME in $PODS; do
       TOTAL_PODS=$((TOTAL_PODS + 1))
@@ -37,7 +34,7 @@ for POD_NAME in $PODS; do
           HAS_TERMINATING_PODS=1
           print_info "Pod $POD_NAME: Terminating (rollout in progress)"
           FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, state: "terminating"}')
-          POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+          add_fact POD_FACTS "$FACT"
           continue
       fi
 
@@ -45,12 +42,12 @@ for POD_NAME in $PODS; do
           READY_PODS=$((READY_PODS + 1))
           print_success "Pod $POD_NAME: Running and Ready"
           FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, state: "ready", phase: "Running"}')
-          POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+          add_fact POD_FACTS "$FACT"
       elif [[ "$POD_PHASE" == "Succeeded" ]]; then
           SUCCEEDED_PODS=$((SUCCEEDED_PODS + 1))
           print_success "Pod $POD_NAME: Completed successfully"
           FACT=$(jq -nc --arg p "$POD_NAME" '{pod: $p, state: "succeeded", phase: "Succeeded"}')
-          POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+          add_fact POD_FACTS "$FACT"
       else
           NOT_READY_PODS=$((NOT_READY_PODS + 1))
           IS_STARTING=0
@@ -110,7 +107,7 @@ for POD_NAME in $PODS; do
                   print_info "Pod $POD_NAME: Phase=$POD_PHASE (starting up)"
               fi
           else
-              mark_affected "$POD_NAME"
+              mark_affected AFFECTED_PODS "$POD_NAME"
               print_warning "Pod $POD_NAME: Phase=$POD_PHASE, Ready=$POD_READY"
           fi
 
@@ -166,7 +163,7 @@ for POD_NAME in $PODS; do
               --arg reason "$READY_REASON" --arg message "$READY_MESSAGE" --arg startup "$STARTUP_INFO" \
               --argjson container_logs "$POD_LOGS_PER_CONTAINER" \
               '{pod: $p, state: $state, phase: $phase, ready: $ready, reason: $reason, message: $message, startup_info: $startup, container_logs: $container_logs}')
-          POD_FACTS=$(echo "$POD_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+          add_fact POD_FACTS "$FACT"
       fi
 done
 
@@ -179,7 +176,7 @@ DETAILS_BASE=$(jq -nc \
     --argjson not_ready "$NOT_READY_PODS" \
     --argjson terminating "$TERMINATING_PODS" \
     --argjson starting "$STARTING_PODS" \
-    --argjson facts "$POD_FACTS" \
+    --argjson facts "$(facts_to_json_array POD_FACTS)" \
     '{
         total: $total,
         ready: $ready,
@@ -228,7 +225,7 @@ else
     EVIDENCE=$(evidence_json \
         "$READY_PODS/$TOTAL_PODS pods ready — $NOT_READY_PODS pod(s) have issues" \
         "critical" \
-        "$AFFECTED_PODS" \
+        "$(set_to_json_array AFFECTED_PODS)" \
         "$DETAILS_BASE" \
         '["Check application health endpoint and ensure dependencies are available"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"

--- a/k8s/diagnose/scope/resource_availability
+++ b/k8s/diagnose/scope/resource_availability
@@ -2,16 +2,20 @@
 # Check: Resource Availability
 # Validates pod can be scheduled with requested resources
 
-# Validate pods exist
 require_pods || return 0
 
-# Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+UNSCHEDULABLE_FACTS="[]"
+AFFECTED_PODS="[]"
+HAS_INSUFFICIENT_CPU=0
+HAS_INSUFFICIENT_MEMORY=0
+
+mark_affected() {
+    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
+}
 
 for POD_NAME in $PODS; do
-    # Get pod info from pre-collected data
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
     POD_PHASE=$(echo "$POD_INFO" | jq -r '.status.phase')
 
@@ -19,27 +23,73 @@ for POD_NAME in $PODS; do
         UNSCHEDULABLE=$(echo "$POD_INFO" | jq -r '.status.conditions[] | select(.reason=="Unschedulable") | .message')
 
         if [[ -n "$UNSCHEDULABLE" ]]; then
-            HAS_ISSUES=1
+            mark_affected "$POD_NAME"
             print_error "Pod $POD_NAME: Cannot be scheduled"
             print_warning "  Reason: $UNSCHEDULABLE"
 
+            POD_HAS_CPU_ISSUE=0
+            POD_HAS_MEMORY_ISSUE=0
             if echo "$UNSCHEDULABLE" | grep -qi "insufficient cpu"; then
                 print_warning "  Issue: Insufficient CPU in cluster"
+                HAS_INSUFFICIENT_CPU=1
+                POD_HAS_CPU_ISSUE=1
             fi
-
             if echo "$UNSCHEDULABLE" | grep -qi "insufficient memory"; then
                 print_warning "  Issue: Insufficient memory in cluster"
+                HAS_INSUFFICIENT_MEMORY=1
+                POD_HAS_MEMORY_ISSUE=1
             fi
 
             print_action "Reduce resource requests or add more nodes to cluster"
+
+            FACT=$(jq -nc \
+                --arg pod "$POD_NAME" \
+                --arg reason "$UNSCHEDULABLE" \
+                --argjson insufficient_cpu "$POD_HAS_CPU_ISSUE" \
+                --argjson insufficient_memory "$POD_HAS_MEMORY_ISSUE" \
+                '{pod: $pod, reason: $reason, insufficient_cpu: ($insufficient_cpu == 1), insufficient_memory: ($insufficient_memory == 1)}')
+            UNSCHEDULABLE_FACTS=$(echo "$UNSCHEDULABLE_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         fi
     fi
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
-    POD_COUNT=$(echo "$PODS" | wc -w)
+POD_COUNT=$(echo "$PODS" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$UNSCHEDULABLE_FACTS" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "All $POD_COUNT pod(s) successfully scheduled with sufficient resources"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "All $POD_COUNT pod(s) successfully scheduled" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson count "$POD_COUNT" '{pods_checked: $count}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    SUMMARY_PARTS=()
+    [[ $HAS_INSUFFICIENT_CPU -eq 1 ]]    && SUMMARY_PARTS+=("insufficient CPU")
+    [[ $HAS_INSUFFICIENT_MEMORY -eq 1 ]] && SUMMARY_PARTS+=("insufficient memory")
+    if [[ ${#SUMMARY_PARTS[@]} -gt 0 ]]; then
+        SUMMARY_DETAIL=$(IFS=", "; echo "${SUMMARY_PARTS[*]}")
+        SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) unschedulable — $SUMMARY_DETAIL"
+    else
+        SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) unschedulable"
+    fi
+
+    DETAILS=$(jq -nc \
+        --argjson unscheduled "$UNSCHEDULABLE_FACTS" \
+        --argjson pod_count "$POD_COUNT" \
+        --argjson cpu "$HAS_INSUFFICIENT_CPU" \
+        --argjson mem "$HAS_INSUFFICIENT_MEMORY" \
+        '{
+            pod_count: $pod_count,
+            unschedulable_count: ($unscheduled | length),
+            cluster_insufficient_cpu: ($cpu == 1),
+            cluster_insufficient_memory: ($mem == 1),
+            unschedulable: $unscheduled
+        }')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+        '["Reduce resource requests or add more nodes to cluster"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/resource_availability
+++ b/k8s/diagnose/scope/resource_availability
@@ -6,14 +6,11 @@ require_pods || return 0
 
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-UNSCHEDULABLE_FACTS="[]"
-AFFECTED_PODS="[]"
+UNSCHEDULABLE_FACTS=()
+AFFECTED_PODS=""
 HAS_INSUFFICIENT_CPU=0
 HAS_INSUFFICIENT_MEMORY=0
 
-mark_affected() {
-    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
-}
 
 for POD_NAME in $PODS; do
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
@@ -23,7 +20,7 @@ for POD_NAME in $PODS; do
         UNSCHEDULABLE=$(echo "$POD_INFO" | jq -r '.status.conditions[] | select(.reason=="Unschedulable") | .message')
 
         if [[ -n "$UNSCHEDULABLE" ]]; then
-            mark_affected "$POD_NAME"
+            mark_affected AFFECTED_PODS "$POD_NAME"
             print_error "Pod $POD_NAME: Cannot be scheduled"
             print_warning "  Reason: $UNSCHEDULABLE"
 
@@ -48,7 +45,7 @@ for POD_NAME in $PODS; do
                 --argjson insufficient_cpu "$POD_HAS_CPU_ISSUE" \
                 --argjson insufficient_memory "$POD_HAS_MEMORY_ISSUE" \
                 '{pod: $pod, reason: $reason, insufficient_cpu: ($insufficient_cpu == 1), insufficient_memory: ($insufficient_memory == 1)}')
-            UNSCHEDULABLE_FACTS=$(echo "$UNSCHEDULABLE_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+            add_fact UNSCHEDULABLE_FACTS "$FACT"
         fi
     fi
 done
@@ -66,7 +63,7 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | wc -w | tr -d ' ')
     SUMMARY_PARTS=()
     [[ $HAS_INSUFFICIENT_CPU -eq 1 ]]    && SUMMARY_PARTS+=("insufficient CPU")
     [[ $HAS_INSUFFICIENT_MEMORY -eq 1 ]] && SUMMARY_PARTS+=("insufficient memory")
@@ -78,7 +75,7 @@ else
     fi
 
     DETAILS=$(jq -nc \
-        --argjson unscheduled "$UNSCHEDULABLE_FACTS" \
+        --argjson unscheduled "$(facts_to_json_array UNSCHEDULABLE_FACTS)" \
         --argjson pod_count "$POD_COUNT" \
         --argjson cpu "$HAS_INSUFFICIENT_CPU" \
         --argjson mem "$HAS_INSUFFICIENT_MEMORY" \
@@ -89,7 +86,7 @@ else
             cluster_insufficient_memory: ($mem == 1),
             unschedulable: $unscheduled
         }')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_PODS)" "$DETAILS" \
         '["Reduce resource requests or add more nodes to cluster"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/storage_mounting
+++ b/k8s/diagnose/scope/storage_mounting
@@ -2,16 +2,18 @@
 # Check: Storage Mounting
 # Verifies persistent volumes are bound and mounted
 
-# Validate pods exist
 require_pods || return 0
 
-# Read pods from pre-collected data
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_STORAGE_ISSUES=0
+PVC_FACTS="[]"
+AFFECTED_PODS="[]"
+
+mark_affected() {
+    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
+}
 
 for POD_NAME in $PODS; do
-    # Get pod info from pre-collected data
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
 
     PVCS=$(echo "$POD_INFO" | jq -r '.spec.volumes[]? | select(.persistentVolumeClaim) | .persistentVolumeClaim.claimName')
@@ -21,20 +23,36 @@ for POD_NAME in $PODS; do
             PVC_STATUS=$(kubectl get pvc "$PVC" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
 
             if [[ "$PVC_STATUS" == "Pending" ]]; then
-                HAS_STORAGE_ISSUES=1
+                mark_affected "$POD_NAME"
                 print_error "Pod $POD_NAME: PVC $PVC is in Pending state"
 
                 PVC_INFO=$(kubectl get pvc "$PVC" -n "$NAMESPACE" -o json 2>/dev/null)
                 STORAGE_CLASS=$(echo "$PVC_INFO" | jq -r '.spec.storageClassName // "default"')
-                REQUESTED_SIZE=$(echo "$PVC_INFO" | jq -r '.spec.resources.requests.storage')
+                REQUESTED_SIZE=$(echo "$PVC_INFO" | jq -r '.spec.resources.requests.storage // ""')
 
                 print_warning "  Storage Class: $STORAGE_CLASS"
                 print_warning "  Requested Size: $REQUESTED_SIZE"
                 print_action "Check if StorageClass exists and has available capacity"
+
+                FACT=$(jq -nc \
+                    --arg pod "$POD_NAME" \
+                    --arg pvc "$PVC" \
+                    --arg status "$PVC_STATUS" \
+                    --arg storage_class "$STORAGE_CLASS" \
+                    --arg requested_size "$REQUESTED_SIZE" \
+                    '{pod: $pod, pvc: $pvc, status: $status, storage_class: $storage_class, requested_size: $requested_size}')
+                PVC_FACTS=$(echo "$PVC_FACTS" | jq --argjson f "$FACT" '. + [$f]')
             elif [[ "$PVC_STATUS" == "Bound" ]]; then
                 print_success "Pod $POD_NAME: PVC $PVC is Bound"
             else
                 print_warning "Pod $POD_NAME: PVC $PVC status is $PVC_STATUS"
+                mark_affected "$POD_NAME"
+                FACT=$(jq -nc \
+                    --arg pod "$POD_NAME" \
+                    --arg pvc "$PVC" \
+                    --arg status "${PVC_STATUS:-Unknown}" \
+                    '{pod: $pod, pvc: $pvc, status: $status}')
+                PVC_FACTS=$(echo "$PVC_FACTS" | jq --argjson f "$FACT" '. + [$f]')
             fi
         done
     fi
@@ -47,10 +65,26 @@ for POD_NAME in $PODS; do
     fi
 done
 
-if [[ $HAS_STORAGE_ISSUES -eq 0 ]]; then
-    POD_COUNT=$(echo "$PODS" | wc -w)
+POD_COUNT=$(echo "$PODS" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$PVC_FACTS" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
     print_success "All volumes mounted successfully for $POD_COUNT pod(s)"
-    update_check_result --status "success" --evidence "{}"
+    EVIDENCE=$(evidence_json \
+        "All volumes mounted successfully for $POD_COUNT pod(s)" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson count "$POD_COUNT" '{pods_checked: $count}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) have storage issues"
+    DETAILS=$(jq -nc \
+        --argjson pvcs "$PVC_FACTS" \
+        --argjson pod_count "$POD_COUNT" \
+        '{pod_count: $pod_count, pvc_issue_count: ($pvcs | length), pvc_issues: $pvcs}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+        '["Check if StorageClass exists and has available capacity"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/scope/storage_mounting
+++ b/k8s/diagnose/scope/storage_mounting
@@ -6,12 +6,9 @@ require_pods || return 0
 
 PODS=$(jq -r '.items[].metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
-PVC_FACTS="[]"
-AFFECTED_PODS="[]"
+PVC_FACTS=()
+AFFECTED_PODS=""
 
-mark_affected() {
-    AFFECTED_PODS=$(echo "$AFFECTED_PODS" | jq --arg p "$1" 'if any(. == $p) then . else . + [$p] end')
-}
 
 for POD_NAME in $PODS; do
     POD_INFO=$(jq --arg name "$POD_NAME" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
@@ -23,7 +20,7 @@ for POD_NAME in $PODS; do
             PVC_STATUS=$(kubectl get pvc "$PVC" -n "$NAMESPACE" -o jsonpath='{.status.phase}' 2>/dev/null)
 
             if [[ "$PVC_STATUS" == "Pending" ]]; then
-                mark_affected "$POD_NAME"
+                mark_affected AFFECTED_PODS "$POD_NAME"
                 print_error "Pod $POD_NAME: PVC $PVC is in Pending state"
 
                 PVC_INFO=$(kubectl get pvc "$PVC" -n "$NAMESPACE" -o json 2>/dev/null)
@@ -41,18 +38,18 @@ for POD_NAME in $PODS; do
                     --arg storage_class "$STORAGE_CLASS" \
                     --arg requested_size "$REQUESTED_SIZE" \
                     '{pod: $pod, pvc: $pvc, status: $status, storage_class: $storage_class, requested_size: $requested_size}')
-                PVC_FACTS=$(echo "$PVC_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+                add_fact PVC_FACTS "$FACT"
             elif [[ "$PVC_STATUS" == "Bound" ]]; then
                 print_success "Pod $POD_NAME: PVC $PVC is Bound"
             else
                 print_warning "Pod $POD_NAME: PVC $PVC status is $PVC_STATUS"
-                mark_affected "$POD_NAME"
+                mark_affected AFFECTED_PODS "$POD_NAME"
                 FACT=$(jq -nc \
                     --arg pod "$POD_NAME" \
                     --arg pvc "$PVC" \
                     --arg status "${PVC_STATUS:-Unknown}" \
                     '{pod: $pod, pvc: $pvc, status: $status}')
-                PVC_FACTS=$(echo "$PVC_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+                add_fact PVC_FACTS "$FACT"
             fi
         done
     fi
@@ -78,13 +75,13 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | jq 'length')
+    AFFECTED_COUNT=$(echo "$AFFECTED_PODS" | wc -w | tr -d ' ')
     SUMMARY="$AFFECTED_COUNT of $POD_COUNT pod(s) have storage issues"
     DETAILS=$(jq -nc \
-        --argjson pvcs "$PVC_FACTS" \
+        --argjson pvcs "$(facts_to_json_array PVC_FACTS)" \
         --argjson pod_count "$POD_COUNT" \
         '{pod_count: $pod_count, pvc_issue_count: ($pvcs | length), pvc_issues: $pvcs}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_PODS" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_PODS)" "$DETAILS" \
         '["Check if StorageClass exists and has available capacity"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/service/service_endpoints
+++ b/k8s/diagnose/service/service_endpoints
@@ -6,26 +6,23 @@ require_services || return 0
 
 SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n' ' ')
 
-ENDPOINT_FACTS="[]"
-AFFECTED_SERVICES="[]"
+ENDPOINT_FACTS=()
+AFFECTED_SERVICES=""
 NO_ENDPOINTS_RESOURCE=0
 NO_READY_COUNT=0
 
-mark_affected() {
-    AFFECTED_SERVICES=$(echo "$AFFECTED_SERVICES" | jq --arg s "$1" 'if any(. == $s) then . else . + [$s] end')
-}
 
 for SERVICE_NAME in $SERVICES; do
     ENDPOINTS_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$ENDPOINTS_FILE" 2>/dev/null)
 
     if [[ -z "$ENDPOINTS_INFO" ]]; then
-        mark_affected "$SERVICE_NAME"
+        mark_affected AFFECTED_SERVICES "$SERVICE_NAME"
         NO_ENDPOINTS_RESOURCE=$((NO_ENDPOINTS_RESOURCE + 1))
         print_error "Service $SERVICE_NAME: No endpoints resource found"
 
         FACT=$(jq -nc --arg svc "$SERVICE_NAME" \
             '{service: $svc, issue: "no_endpoints_resource", ready_count: 0, not_ready_count: 0}')
-        ENDPOINT_FACTS=$(echo "$ENDPOINT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact ENDPOINT_FACTS "$FACT"
         continue
     fi
 
@@ -41,7 +38,7 @@ for SERVICE_NAME in $SERVICES; do
     NOT_READY_LIST=$(echo "$ENDPOINTS_INFO" | jq -c '[.subsets[]?.notReadyAddresses[]? | {pod: (.targetRef.name // "unknown"), ip: .ip}]' 2>/dev/null)
 
     if [[ $READY_COUNT -eq 0 ]]; then
-        mark_affected "$SERVICE_NAME"
+        mark_affected AFFECTED_SERVICES "$SERVICE_NAME"
         NO_READY_COUNT=$((NO_READY_COUNT + 1))
         print_error "Service $SERVICE_NAME: No ready endpoints available"
 
@@ -64,7 +61,7 @@ for SERVICE_NAME in $SERVICES; do
             --argjson ready_count "$READY_COUNT" --argjson not_ready_count "$NOT_READY_COUNT" \
             --argjson not_ready "$NOT_READY_LIST" \
             '{service: $svc, issue: "no_ready_endpoints", ready_count: $ready_count, not_ready_count: $not_ready_count, not_ready_endpoints: $not_ready}')
-        ENDPOINT_FACTS=$(echo "$ENDPOINT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact ENDPOINT_FACTS "$FACT"
     else
         print_success "Service $SERVICE_NAME: $READY_COUNT ready endpoint(s)"
         echo "$ENDPOINTS_INFO" | jq -r '.subsets[]?.addresses[]? | "  - \(.targetRef.name // "unknown") -> \(.ip)"' | while IFS= read -r line; do
@@ -84,25 +81,25 @@ for SERVICE_NAME in $SERVICES; do
             --argjson ready_count "$READY_COUNT" --argjson not_ready_count "$NOT_READY_COUNT" \
             --argjson ready "$READY_LIST" --argjson not_ready "$NOT_READY_LIST" \
             '{service: $svc, ready_count: $ready_count, not_ready_count: $not_ready_count, ready_endpoints: $ready, not_ready_endpoints: $not_ready}')
-        ENDPOINT_FACTS=$(echo "$ENDPOINT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact ENDPOINT_FACTS "$FACT"
     fi
 done
 
 SERVICE_COUNT=$(echo "$SERVICES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     EVIDENCE=$(evidence_json \
         "All $SERVICE_COUNT service(s) have ready endpoints" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$ENDPOINT_FACTS" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array ENDPOINT_FACTS)" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $SERVICE_COUNT service(s) without ready endpoints"
     DETAILS=$(jq -nc \
-        --argjson facts "$ENDPOINT_FACTS" \
+        --argjson facts "$(facts_to_json_array ENDPOINT_FACTS)" \
         --argjson count "$SERVICE_COUNT" \
         --argjson no_resource "$NO_ENDPOINTS_RESOURCE" \
         --argjson no_ready "$NO_READY_COUNT" \
@@ -113,7 +110,7 @@ else
             no_ready_endpoints_count: $no_ready,
             services: $facts
         }')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_SERVICES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_SERVICES)" "$DETAILS" \
         '["Check pod readiness probes and verify service selector matches pod labels"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/service/service_endpoints
+++ b/k8s/diagnose/service/service_endpoints
@@ -2,50 +2,56 @@
 # Check: Service Endpoints
 # Checks if service has healthy endpoints
 
-# Validate services exist
 require_services || return 0
 
-# Read services from pre-collected data
 SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+ENDPOINT_FACTS="[]"
+AFFECTED_SERVICES="[]"
+NO_ENDPOINTS_RESOURCE=0
+NO_READY_COUNT=0
+
+mark_affected() {
+    AFFECTED_SERVICES=$(echo "$AFFECTED_SERVICES" | jq --arg s "$1" 'if any(. == $s) then . else . + [$s] end')
+}
 
 for SERVICE_NAME in $SERVICES; do
-    # Get endpoints from pre-collected data
     ENDPOINTS_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$ENDPOINTS_FILE" 2>/dev/null)
 
     if [[ -z "$ENDPOINTS_INFO" ]]; then
-        HAS_ISSUES=1
+        mark_affected "$SERVICE_NAME"
+        NO_ENDPOINTS_RESOURCE=$((NO_ENDPOINTS_RESOURCE + 1))
         print_error "Service $SERVICE_NAME: No endpoints resource found"
+
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" \
+            '{service: $svc, issue: "no_endpoints_resource", ready_count: 0, not_ready_count: 0}')
+        ENDPOINT_FACTS=$(echo "$ENDPOINT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
-    # Check if endpoints has any addresses with detailed info
-    # Get ports for this subset
     PORTS=$(echo "$ENDPOINTS_INFO" | jq -r '.subsets[0]?.ports[]? | "\(.port):\(.name // "unnamed")"' 2>/dev/null | head -1)
     PORT_NUMBER=$(echo "$PORTS" | cut -d':' -f1)
-    PORT_NAME=$(echo "$PORTS" | cut -d':' -f2)
 
-    READY_ENDPOINTS=$(echo "$ENDPOINTS_INFO" | jq -r '.subsets[]?.addresses[]? | "\(.targetRef.name // "unknown"):\(.ip)"' 2>/dev/null)
-    NOT_READY_ENDPOINTS=$(echo "$ENDPOINTS_INFO" | jq -r '.subsets[]?.notReadyAddresses[]? | "\(.targetRef.name // "unknown"):\(.ip)"' 2>/dev/null)
+    READY_COUNT=$(echo "$ENDPOINTS_INFO" | jq -r '[.subsets[]?.addresses[]?] | length' 2>/dev/null)
+    NOT_READY_COUNT=$(echo "$ENDPOINTS_INFO" | jq -r '[.subsets[]?.notReadyAddresses[]?] | length' 2>/dev/null)
+    READY_COUNT=${READY_COUNT:-0}
+    NOT_READY_COUNT=${NOT_READY_COUNT:-0}
 
-    READY_COUNT=$(echo "$READY_ENDPOINTS" | grep -c '^' 2>/dev/null || echo 0)
-    NOT_READY_COUNT=$(echo "$NOT_READY_ENDPOINTS" | grep -c '^' 2>/dev/null || echo 0)
+    READY_LIST=$(echo "$ENDPOINTS_INFO" | jq -c '[.subsets[]?.addresses[]? | {pod: (.targetRef.name // "unknown"), ip: .ip}]' 2>/dev/null)
+    NOT_READY_LIST=$(echo "$ENDPOINTS_INFO" | jq -c '[.subsets[]?.notReadyAddresses[]? | {pod: (.targetRef.name // "unknown"), ip: .ip}]' 2>/dev/null)
 
     if [[ $READY_COUNT -eq 0 ]]; then
-        HAS_ISSUES=1
+        mark_affected "$SERVICE_NAME"
+        NO_READY_COUNT=$((NO_READY_COUNT + 1))
         print_error "Service $SERVICE_NAME: No ready endpoints available"
 
         if [[ $NOT_READY_COUNT -gt 0 ]]; then
-            print_warning "  Not ready endpoints: $NOT_READY_COUNT"
-            # Show details of not ready endpoints
-            echo "$NOT_READY_ENDPOINTS" | while IFS=':' read -r POD_NAME IP; do
-                if [[ -n "$IP" ]]; then
-                    if [[ -n "$PORT_NUMBER" ]]; then
-                        print_warning "    - $POD_NAME -> $IP:$PORT_NUMBER"
-                    else
-                        print_warning "    - $POD_NAME -> $IP"
-                    fi
+            print_warning "  $NOT_READY_COUNT not ready endpoint(s):"
+            echo "$ENDPOINTS_INFO" | jq -r '.subsets[]?.notReadyAddresses[]? | "    - \(.targetRef.name // "unknown") -> \(.ip)"' | while IFS= read -r line; do
+                if [[ -n "$PORT_NUMBER" ]]; then
+                    print_warning "${line}:${PORT_NUMBER}"
+                else
+                    print_warning "$line"
                 fi
             done
             print_action "Check pod readiness probes and pod status"
@@ -53,39 +59,61 @@ for SERVICE_NAME in $SERVICES; do
             print_warning "  No endpoints at all"
             print_action "Verify service selector matches pod labels"
         fi
+
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" \
+            --argjson ready_count "$READY_COUNT" --argjson not_ready_count "$NOT_READY_COUNT" \
+            --argjson not_ready "$NOT_READY_LIST" \
+            '{service: $svc, issue: "no_ready_endpoints", ready_count: $ready_count, not_ready_count: $not_ready_count, not_ready_endpoints: $not_ready}')
+        ENDPOINT_FACTS=$(echo "$ENDPOINT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
     else
         print_success "Service $SERVICE_NAME: $READY_COUNT ready endpoint(s)"
-
-        # Show details of ready endpoints
-        echo "$READY_ENDPOINTS" | while IFS=':' read -r POD_NAME IP; do
-            if [[ -n "$IP" ]]; then
-                if [[ -n "$PORT_NUMBER" ]]; then
-                    print_success "  - $POD_NAME -> $IP:$PORT_NUMBER"
-                else
-                    print_success "  - $POD_NAME -> $IP"
-                fi
+        echo "$ENDPOINTS_INFO" | jq -r '.subsets[]?.addresses[]? | "  - \(.targetRef.name // "unknown") -> \(.ip)"' | while IFS= read -r line; do
+            if [[ -n "$PORT_NUMBER" ]]; then
+                print_success "${line}:${PORT_NUMBER}"
+            else
+                print_success "$line"
             fi
         done
 
         if [[ $NOT_READY_COUNT -gt 0 ]]; then
             print_warning "  Also has $NOT_READY_COUNT not ready endpoint(s)"
-            # Show details of not ready endpoints
-            echo "$NOT_READY_ENDPOINTS" | while IFS=':' read -r POD_NAME IP; do
-                if [[ -n "$IP" ]]; then
-                    if [[ -n "$PORT_NUMBER" ]]; then
-                        print_warning "    - $POD_NAME -> $IP:$PORT_NUMBER"
-                    else
-                        print_warning "    - $POD_NAME -> $IP"
-                    fi
-                fi
-            done
             print_action "Check pod readiness probes and pod status"
         fi
+
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" \
+            --argjson ready_count "$READY_COUNT" --argjson not_ready_count "$NOT_READY_COUNT" \
+            --argjson ready "$READY_LIST" --argjson not_ready "$NOT_READY_LIST" \
+            '{service: $svc, ready_count: $ready_count, not_ready_count: $not_ready_count, ready_endpoints: $ready, not_ready_endpoints: $not_ready}')
+        ENDPOINT_FACTS=$(echo "$ENDPOINT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
     fi
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
-    update_check_result --status "success" --evidence "{}"
+SERVICE_COUNT=$(echo "$SERVICES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
+    EVIDENCE=$(evidence_json \
+        "All $SERVICE_COUNT service(s) have ready endpoints" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$ENDPOINT_FACTS" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $SERVICE_COUNT service(s) without ready endpoints"
+    DETAILS=$(jq -nc \
+        --argjson facts "$ENDPOINT_FACTS" \
+        --argjson count "$SERVICE_COUNT" \
+        --argjson no_resource "$NO_ENDPOINTS_RESOURCE" \
+        --argjson no_ready "$NO_READY_COUNT" \
+        '{
+            service_count: $count,
+            issue_count: ($facts | map(select(.issue != null)) | length),
+            no_endpoints_resource_count: $no_resource,
+            no_ready_endpoints_count: $no_ready,
+            services: $facts
+        }')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_SERVICES" "$DETAILS" \
+        '["Check pod readiness probes and verify service selector matches pod labels"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/service/service_existence
+++ b/k8s/diagnose/service/service_existence
@@ -7,10 +7,26 @@ SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n'
 if [[ -z "$SERVICES" ]]; then
     print_error "No services found with labels $LABEL_SELECTOR in namespace $NAMESPACE"
     print_action "Create service resource or verify label selectors"
-    update_check_result --status "failed" --evidence "{}"
+
+    EVIDENCE=$(evidence_json \
+        "No services found in namespace $NAMESPACE" \
+        "critical" \
+        "[]" \
+        "$(jq -nc --arg ls "$LABEL_SELECTOR" --arg ns "$NAMESPACE" '{label_selector: $ls, namespace: $ns}')" \
+        '["Create service resource or verify label selectors"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
     return 1
 fi
 
-SERVICE_COUNT=$(echo "$SERVICES" | wc -w)
+SERVICE_NAMES_JSON=$(jq -c '[.items[].metadata.name]' "$SERVICES_FILE" 2>/dev/null)
+SERVICE_COUNT=$(echo "$SERVICES" | wc -w | tr -d ' ')
 print_success "Found $SERVICE_COUNT service(s): $SERVICES"
-update_check_result --status "success" --evidence "{}"
+
+EVIDENCE=$(evidence_json \
+    "Found $SERVICE_COUNT service(s) in namespace $NAMESPACE" \
+    "info" \
+    "[]" \
+    "$(jq -nc --argjson count "$SERVICE_COUNT" --argjson names "$SERVICE_NAMES_JSON" --arg ns "$NAMESPACE" \
+        '{service_count: $count, service_names: $names, namespace: $ns}')" \
+    "[]")
+update_check_result --status "success" --evidence "$EVIDENCE"

--- a/k8s/diagnose/service/service_port_configuration
+++ b/k8s/diagnose/service/service_port_configuration
@@ -6,12 +6,9 @@ require_services || return 0
 
 SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n' ' ')
 
-PORT_FACTS="[]"
-AFFECTED_SERVICES="[]"
+PORT_FACTS=()
+AFFECTED_SERVICES=""
 
-mark_affected() {
-    AFFECTED_SERVICES=$(echo "$AFFECTED_SERVICES" | jq --arg s "$1" 'if any(. == $s) then . else . + [$s] end')
-}
 
 for SERVICE_NAME in $SERVICES; do
     SERVICE_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$SERVICES_FILE" 2>/dev/null)
@@ -19,10 +16,10 @@ for SERVICE_NAME in $SERVICES; do
     SERVICE_PORTS=$(echo "$SERVICE_INFO" | jq -r '.spec.ports[] | "\(.port):\(.targetPort):\(.name // "unnamed")"')
 
     if [[ -z "$SERVICE_PORTS" ]]; then
-        mark_affected "$SERVICE_NAME"
+        mark_affected AFFECTED_SERVICES "$SERVICE_NAME"
         print_error "Service $SERVICE_NAME: No ports defined"
         FACT=$(jq -nc --arg svc "$SERVICE_NAME" '{service: $svc, issue: "no_ports_defined", ports: []}')
-        PORT_FACTS=$(echo "$PORT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact PORT_FACTS "$FACT"
         continue
     fi
 
@@ -31,7 +28,7 @@ for SERVICE_NAME in $SERVICES; do
     if [[ -z "$SERVICE_SELECTORS" || "$SERVICE_SELECTORS" == "null" ]]; then
         print_warning "Service $SERVICE_NAME: No selector, skipping port validation"
         FACT=$(jq -nc --arg svc "$SERVICE_NAME" '{service: $svc, issue: "no_selector_skipped"}')
-        PORT_FACTS=$(echo "$PORT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact PORT_FACTS "$FACT"
         continue
     fi
 
@@ -49,7 +46,7 @@ for SERVICE_NAME in $SERVICES; do
     if [[ -z "$PODS" ]]; then
         print_warning "Service $SERVICE_NAME: No pods found to validate ports"
         FACT=$(jq -nc --arg svc "$SERVICE_NAME" '{service: $svc, issue: "no_pods_for_validation"}')
-        PORT_FACTS=$(echo "$PORT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact PORT_FACTS "$FACT"
         continue
     fi
 
@@ -58,7 +55,7 @@ for SERVICE_NAME in $SERVICES; do
 
     print_info "Service $SERVICE_NAME port configuration:"
 
-    PORT_RESULTS="[]"
+    PORT_RESULTS=()
     SERVICE_HAS_ISSUE=0
 
     while IFS=':' read -r SERVICE_PORT TARGET_PORT PORT_NAME; do
@@ -87,7 +84,7 @@ for SERVICE_NAME in $SERVICES; do
                 PORT_RESULT=$(jq -nc --arg svc_port "$SERVICE_PORT" --arg target "$TARGET_PORT" --arg name "$PORT_NAME" \
                     --argjson available "$AVAILABLE_PORTS" \
                     '{service_port: $svc_port, target_port: $target, port_name: $name, status: "container_port_not_found", available_ports_by_container: $available}')
-                PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson r "$PORT_RESULT" '. + [$r]')
+                add_fact PORT_RESULTS "$PORT_RESULT"
                 continue
             fi
         else
@@ -109,7 +106,7 @@ for SERVICE_NAME in $SERVICES; do
                 print_action "Define named port in container spec or use numeric targetPort"
                 PORT_RESULT=$(jq -nc --arg svc_port "$SERVICE_PORT" --arg target "$TARGET_PORT" --arg name "$PORT_NAME" \
                     '{service_port: $svc_port, target_port: $target, port_name: $name, status: "named_port_not_found"}')
-                PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson r "$PORT_RESULT" '. + [$r]')
+                add_fact PORT_RESULTS "$PORT_RESULT"
                 continue
             fi
         fi
@@ -130,34 +127,34 @@ for SERVICE_NAME in $SERVICES; do
             PORT_RESULT=$(echo "$PORT_RESULT" | jq '. + {connectivity: "refused", status: "not_listening"}')
         fi
 
-        PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson r "$PORT_RESULT" '. + [$r]')
+        add_fact PORT_RESULTS "$PORT_RESULT"
     done < <(echo "$SERVICE_PORTS")
 
-    [[ $SERVICE_HAS_ISSUE -eq 1 ]] && mark_affected "$SERVICE_NAME"
+    [[ $SERVICE_HAS_ISSUE -eq 1 ]] && mark_affected AFFECTED_SERVICES "$SERVICE_NAME"
 
-    FACT=$(jq -nc --arg svc "$SERVICE_NAME" --argjson ports "$PORT_RESULTS" \
+    FACT=$(jq -nc --arg svc "$SERVICE_NAME" --argjson ports "$(facts_to_json_array PORT_RESULTS)" \
         '{service: $svc, ports: $ports}')
-    PORT_FACTS=$(echo "$PORT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+    add_fact PORT_FACTS "$FACT"
 done
 
 SERVICE_COUNT=$(echo "$SERVICES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     EVIDENCE=$(evidence_json \
         "All $SERVICE_COUNT service(s) have valid port configuration" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$PORT_FACTS" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array PORT_FACTS)" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $SERVICE_COUNT service(s) have port configuration issues"
     DETAILS=$(jq -nc \
-        --argjson facts "$PORT_FACTS" \
+        --argjson facts "$(facts_to_json_array PORT_FACTS)" \
         --argjson count "$SERVICE_COUNT" \
         '{service_count: $count, issue_count: ($facts | map(select(.ports[]? | .status != "ok")) | length), services: $facts}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_SERVICES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_SERVICES)" "$DETAILS" \
         '["Verify container is listening on targetPort and that ports/protocols match"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/service/service_port_configuration
+++ b/k8s/diagnose/service/service_port_configuration
@@ -2,36 +2,39 @@
 # Check: Service Port Configuration
 # Validates service and container port alignment
 
-# Validate services exist
 require_services || return 0
 
-# Read services from pre-collected data
 SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_PORT_ISSUES=0
+PORT_FACTS="[]"
+AFFECTED_SERVICES="[]"
+
+mark_affected() {
+    AFFECTED_SERVICES=$(echo "$AFFECTED_SERVICES" | jq --arg s "$1" 'if any(. == $s) then . else . + [$s] end')
+}
 
 for SERVICE_NAME in $SERVICES; do
-    # Get service info from pre-collected data
     SERVICE_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$SERVICES_FILE" 2>/dev/null)
 
-    # Get service ports and targetPorts
     SERVICE_PORTS=$(echo "$SERVICE_INFO" | jq -r '.spec.ports[] | "\(.port):\(.targetPort):\(.name // "unnamed")"')
 
     if [[ -z "$SERVICE_PORTS" ]]; then
-        HAS_PORT_ISSUES=1
+        mark_affected "$SERVICE_NAME"
         print_error "Service $SERVICE_NAME: No ports defined"
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" '{service: $svc, issue: "no_ports_defined", ports: []}')
+        PORT_FACTS=$(echo "$PORT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
-    # Get service selector to find pods
     SERVICE_SELECTORS=$(echo "$SERVICE_INFO" | jq -c '.spec.selector')
 
     if [[ -z "$SERVICE_SELECTORS" || "$SERVICE_SELECTORS" == "null" ]]; then
         print_warning "Service $SERVICE_NAME: No selector, skipping port validation"
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" '{service: $svc, issue: "no_selector_skipped"}')
+        PORT_FACTS=$(echo "$PORT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
-    # Find pods from pre-collected data that match service selectors
     PODS=$(jq -r --argjson selectors "$SERVICE_SELECTORS" '
                .items[] |
                . as $pod |
@@ -45,24 +48,24 @@ for SERVICE_NAME in $SERVICES; do
 
     if [[ -z "$PODS" ]]; then
         print_warning "Service $SERVICE_NAME: No pods found to validate ports"
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" '{service: $svc, issue: "no_pods_for_validation"}')
+        PORT_FACTS=$(echo "$PORT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
-    # Check first pod for port validation
     FIRST_POD=$(echo "$PODS" | awk '{print $1}')
     POD_INFO=$(jq --arg name "$FIRST_POD" '.items[] | select(.metadata.name == $name)' "$PODS_FILE" 2>/dev/null)
 
     print_info "Service $SERVICE_NAME port configuration:"
 
-    # Validate configuration and test connectivity
-    # Use process substitution to avoid subshell and preserve HAS_PORT_ISSUES updates
+    PORT_RESULTS="[]"
+    SERVICE_HAS_ISSUE=0
+
     while IFS=':' read -r SERVICE_PORT TARGET_PORT PORT_NAME; do
         ACTUAL_TARGET_PORT="$TARGET_PORT"
         CONTAINER_NAME=""
 
-        # Check if targetPort is numeric or named
         if [[ "$TARGET_PORT" =~ ^[0-9]+$ ]]; then
-            # Numeric targetPort - find which container has this port
             CONTAINER_INFO=$(echo "$POD_INFO" | jq -r --arg port "$TARGET_PORT" '
                 .spec.containers[] |
                 select(.ports[]?.containerPort == ($port | tonumber)) |
@@ -72,17 +75,22 @@ for SERVICE_NAME in $SERVICES; do
             if [[ -n "$CONTAINER_INFO" ]]; then
                 CONTAINER_NAME=$(echo "$CONTAINER_INFO" | cut -d':' -f1)
                 print_success "  Port $SERVICE_PORT -> $TARGET_PORT ($PORT_NAME): Configuration OK [container: $CONTAINER_NAME]"
+                PORT_RESULT=$(jq -nc --arg svc_port "$SERVICE_PORT" --arg target "$TARGET_PORT" --arg name "$PORT_NAME" --arg cont "$CONTAINER_NAME" \
+                    '{service_port: $svc_port, target_port: $target, port_name: $name, container: $cont, status: "ok"}')
             else
-                HAS_PORT_ISSUES=1
-                # Show available ports per container
-                AVAILABLE_PORTS=$(echo "$POD_INFO" | jq -r '.spec.containers[] | "\(.name): \([.ports[]?.containerPort] | join(","))"' | tr '\n' '; ')
+                SERVICE_HAS_ISSUE=1
+                AVAILABLE_PORTS=$(echo "$POD_INFO" | jq -c '[.spec.containers[] | {container: .name, ports: [.ports[]?.containerPort]}]')
                 print_error "  Port $SERVICE_PORT -> $TARGET_PORT ($PORT_NAME): Container port $TARGET_PORT not found"
-                print_warning "    Available ports by container: $AVAILABLE_PORTS"
+                AVAILABLE_HUMAN=$(echo "$POD_INFO" | jq -r '.spec.containers[] | "\(.name): \([.ports[]?.containerPort] | join(","))"' | tr '\n' '; ')
+                print_warning "    Available ports by container: $AVAILABLE_HUMAN"
                 print_action "Update service targetPort to match container port or fix container port"
+                PORT_RESULT=$(jq -nc --arg svc_port "$SERVICE_PORT" --arg target "$TARGET_PORT" --arg name "$PORT_NAME" \
+                    --argjson available "$AVAILABLE_PORTS" \
+                    '{service_port: $svc_port, target_port: $target, port_name: $name, status: "container_port_not_found", available_ports_by_container: $available}')
+                PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson r "$PORT_RESULT" '. + [$r]')
                 continue
             fi
         else
-            # Named port - find which container has this named port
             CONTAINER_INFO=$(echo "$POD_INFO" | jq -r --arg portname "$TARGET_PORT" '
                 .spec.containers[] |
                 select(.ports[]? | select(.name == $portname)) |
@@ -93,34 +101,63 @@ for SERVICE_NAME in $SERVICES; do
                 CONTAINER_NAME=$(echo "$CONTAINER_INFO" | cut -d':' -f1)
                 ACTUAL_TARGET_PORT=$(echo "$CONTAINER_INFO" | cut -d':' -f2)
                 print_success "  Port $SERVICE_PORT -> $TARGET_PORT ($PORT_NAME): Resolves to $ACTUAL_TARGET_PORT [container: $CONTAINER_NAME]"
+                PORT_RESULT=$(jq -nc --arg svc_port "$SERVICE_PORT" --arg target "$TARGET_PORT" --arg name "$PORT_NAME" --arg cont "$CONTAINER_NAME" --arg actual "$ACTUAL_TARGET_PORT" \
+                    '{service_port: $svc_port, target_port: $target, port_name: $name, container: $cont, resolved_port: $actual, status: "ok"}')
             else
-                HAS_PORT_ISSUES=1
+                SERVICE_HAS_ISSUE=1
                 print_error "  Port $SERVICE_PORT -> $TARGET_PORT ($PORT_NAME): Named port not found in containers"
                 print_action "Define named port in container spec or use numeric targetPort"
+                PORT_RESULT=$(jq -nc --arg svc_port "$SERVICE_PORT" --arg target "$TARGET_PORT" --arg name "$PORT_NAME" \
+                    '{service_port: $svc_port, target_port: $target, port_name: $name, status: "named_port_not_found"}')
+                PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson r "$PORT_RESULT" '. + [$r]')
                 continue
             fi
         fi
 
-        # Active connectivity check - verify application is listening on the port
+        # Active connectivity check
         print_info "    Testing connectivity to port $ACTUAL_TARGET_PORT in container '$CONTAINER_NAME'..."
-
-        # Try to connect to the port from inside the specific container
-        CONNECTIVITY_TEST=$(kubectl exec "$FIRST_POD" -n "$NAMESPACE" -c "$CONTAINER_NAME" -- timeout 2 sh -c "command -v nc >/dev/null 2>&1 && nc -z localhost $ACTUAL_TARGET_PORT || (command -v curl >/dev/null 2>&1 && curl -s --max-time 1 localhost:$ACTUAL_TARGET_PORT >/dev/null)" 2>&1)
+        kubectl exec "$FIRST_POD" -n "$NAMESPACE" -c "$CONTAINER_NAME" -- timeout 2 sh -c "command -v nc >/dev/null 2>&1 && nc -z localhost $ACTUAL_TARGET_PORT || (command -v curl >/dev/null 2>&1 && curl -s --max-time 1 localhost:$ACTUAL_TARGET_PORT >/dev/null)" 2>&1 >/dev/null
         CONNECTIVITY_EXIT_CODE=$?
 
         if [[ $CONNECTIVITY_EXIT_CODE -eq 0 ]]; then
             print_success "    ✓ Port $ACTUAL_TARGET_PORT is accepting connections"
+            PORT_RESULT=$(echo "$PORT_RESULT" | jq '. + {connectivity: "ok"}')
         else
-            HAS_PORT_ISSUES=1
+            SERVICE_HAS_ISSUE=1
             print_error "    ✗ Port $ACTUAL_TARGET_PORT is NOT accepting connections"
             print_warning "    Configuration is correct but application may not be listening on port $ACTUAL_TARGET_PORT"
             print_info "    Check logs: kubectl logs $FIRST_POD -n $NAMESPACE -c $CONTAINER_NAME"
+            PORT_RESULT=$(echo "$PORT_RESULT" | jq '. + {connectivity: "refused", status: "not_listening"}')
         fi
+
+        PORT_RESULTS=$(echo "$PORT_RESULTS" | jq --argjson r "$PORT_RESULT" '. + [$r]')
     done < <(echo "$SERVICE_PORTS")
+
+    [[ $SERVICE_HAS_ISSUE -eq 1 ]] && mark_affected "$SERVICE_NAME"
+
+    FACT=$(jq -nc --arg svc "$SERVICE_NAME" --argjson ports "$PORT_RESULTS" \
+        '{service: $svc, ports: $ports}')
+    PORT_FACTS=$(echo "$PORT_FACTS" | jq --argjson f "$FACT" '. + [$f]')
 done
 
-if [[ $HAS_PORT_ISSUES -eq 0 ]]; then
-    update_check_result --status "success" --evidence "{}"
+SERVICE_COUNT=$(echo "$SERVICES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
+    EVIDENCE=$(evidence_json \
+        "All $SERVICE_COUNT service(s) have valid port configuration" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$PORT_FACTS" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $SERVICE_COUNT service(s) have port configuration issues"
+    DETAILS=$(jq -nc \
+        --argjson facts "$PORT_FACTS" \
+        --argjson count "$SERVICE_COUNT" \
+        '{service_count: $count, issue_count: ($facts | map(select(.ports[]? | .status != "ok")) | length), services: $facts}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_SERVICES" "$DETAILS" \
+        '["Verify container is listening on targetPort and that ports/protocols match"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/service/service_selector_match
+++ b/k8s/diagnose/service/service_selector_match
@@ -6,12 +6,9 @@ require_services || return 0
 
 SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n' ' ')
 
-SELECTOR_FACTS="[]"
-AFFECTED_SERVICES="[]"
+SELECTOR_FACTS=()
+AFFECTED_SERVICES=""
 
-mark_affected() {
-    AFFECTED_SERVICES=$(echo "$AFFECTED_SERVICES" | jq --arg s "$1" 'if any(. == $s) then . else . + [$s] end')
-}
 
 for SERVICE_NAME in $SERVICES; do
     SERVICE_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$SERVICES_FILE" 2>/dev/null)
@@ -20,11 +17,11 @@ for SERVICE_NAME in $SERVICES; do
     SELECTOR_OBJECT=$(echo "$SERVICE_INFO" | jq -c '.spec.selector')
 
     if [[ -z "$SERVICE_SELECTORS" || "$SERVICE_SELECTORS" == "null" ]]; then
-        mark_affected "$SERVICE_NAME"
+        mark_affected AFFECTED_SERVICES "$SERVICE_NAME"
         print_error "Service $SERVICE_NAME: No selector defined"
 
         FACT=$(jq -nc --arg svc "$SERVICE_NAME" '{service: $svc, issue: "no_selector"}')
-        SELECTOR_FACTS=$(echo "$SELECTOR_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact SELECTOR_FACTS "$FACT"
         continue
     fi
 
@@ -40,11 +37,12 @@ for SERVICE_NAME in $SERVICES; do
     ' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
     if [[ -z "$MATCHING_PODS" ]]; then
-        mark_affected "$SERVICE_NAME"
+        mark_affected AFFECTED_SERVICES "$SERVICE_NAME"
         print_error "Service $SERVICE_NAME: No pods match selector ($SERVICE_SELECTORS)"
 
         EXISTING_PODS=$(jq -r --arg dep_id "$DEPLOYMENT_ID" '.items[] | select(.metadata.labels.deployment_id == $dep_id) | .metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
-        MISMATCH_FACTS="[]"
+        MISMATCH_FACTS=()
+        MISMATCH_FACTS_JSON="[]"
 
         if [[ -n "$EXISTING_PODS" ]]; then
             print_warning "  Existing pods with deployment_id: $EXISTING_PODS"
@@ -61,11 +59,11 @@ for SERVICE_NAME in $SERVICES; do
                 if [[ "$POD_VALUE" == "MISSING" ]]; then
                     MM=$(jq -nc --arg key "$key" --arg expected "$value" --arg actual "MISSING" \
                         '{key: $key, selector_value: $expected, pod_value: $actual, kind: "missing"}')
-                    MISMATCH_FACTS=$(echo "$MISMATCH_FACTS" | jq --argjson m "$MM" '. + [$m]')
+                    add_fact MISMATCH_FACTS "$MM"
                 elif [[ "$POD_VALUE" != "$value" ]]; then
                     MM=$(jq -nc --arg key "$key" --arg expected "$value" --arg actual "$POD_VALUE" \
                         '{key: $key, selector_value: $expected, pod_value: $actual, kind: "mismatch"}')
-                    MISMATCH_FACTS=$(echo "$MISMATCH_FACTS" | jq --argjson m "$MM" '. + [$m]')
+                    add_fact MISMATCH_FACTS "$MM"
                 else
                     MATCH_COUNT=$((MATCH_COUNT + 1))
                 fi
@@ -73,10 +71,10 @@ for SERVICE_NAME in $SERVICES; do
 
             print_info "  Selector check: $MATCH_COUNT/$SELECTOR_COUNT labels match"
 
-            MISMATCH_LEN=$(echo "$MISMATCH_FACTS" | jq 'length')
-            if [[ $MISMATCH_LEN -gt 0 ]]; then
+            MISMATCH_FACTS_JSON=$(facts_to_json_array MISMATCH_FACTS)
+            if [[ ${#MISMATCH_FACTS[@]} -gt 0 ]]; then
                 print_warning "  Selector mismatches:"
-                echo "$MISMATCH_FACTS" | jq -r '.[] | "    ✗ " + .key + ": selector=" + .selector_value + ", pod=" + .pod_value' | while IFS= read -r line; do
+                echo "$MISMATCH_FACTS_JSON" | jq -r '.[] | "    ✗ " + .key + ": selector=" + .selector_value + ", pod=" + .pod_value' | while IFS= read -r line; do
                     print_warning "$line"
                 done
             fi
@@ -85,38 +83,38 @@ for SERVICE_NAME in $SERVICES; do
         fi
 
         FACT=$(jq -nc --arg svc "$SERVICE_NAME" --argjson sel "$SELECTOR_OBJECT" \
-            --argjson mismatches "$MISMATCH_FACTS" \
+            --argjson mismatches "$MISMATCH_FACTS_JSON" \
             --arg existing_pods "$EXISTING_PODS" \
             '{service: $svc, issue: "no_matching_pods", selector: $sel, existing_pods_with_deployment_id: ($existing_pods | split(" ") | map(select(length > 0))), label_mismatches: $mismatches}')
-        SELECTOR_FACTS=$(echo "$SELECTOR_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact SELECTOR_FACTS "$FACT"
     else
         POD_COUNT=$(echo "$MATCHING_PODS" | wc -w | tr -d ' ')
         print_success "Service $SERVICE_NAME: Selector matches $POD_COUNT pod(s)"
         FACT=$(jq -nc --arg svc "$SERVICE_NAME" --argjson sel "$SELECTOR_OBJECT" \
             --argjson matched "$POD_COUNT" \
             '{service: $svc, selector: $sel, matched_pod_count: $matched}')
-        SELECTOR_FACTS=$(echo "$SELECTOR_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+        add_fact SELECTOR_FACTS "$FACT"
     fi
 done
 
 SERVICE_COUNT=$(echo "$SERVICES" | wc -w | tr -d ' ')
-ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | jq 'length')
+ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | wc -w | tr -d ' ')
 
 if [[ $ISSUE_COUNT -eq 0 ]]; then
     EVIDENCE=$(evidence_json \
         "All $SERVICE_COUNT service(s) match at least one pod" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson facts "$SELECTOR_FACTS" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
+        "$(jq -nc --argjson facts "$(facts_to_json_array SELECTOR_FACTS)" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $SERVICE_COUNT service(s) have selector issues"
     DETAILS=$(jq -nc \
-        --argjson facts "$SELECTOR_FACTS" \
+        --argjson facts "$(facts_to_json_array SELECTOR_FACTS)" \
         --argjson count "$SERVICE_COUNT" \
         '{service_count: $count, issue_count: ($facts | map(select(.issue != null)) | length), services: $facts}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_SERVICES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$(set_to_json_array AFFECTED_SERVICES)" "$DETAILS" \
         '["Verify pod labels match service selector"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/service/service_selector_match
+++ b/k8s/diagnose/service/service_selector_match
@@ -2,32 +2,32 @@
 # Check: Service Selector Match
 # Validates service selectors match pod labels
 
-# Validate services exist
 require_services || return 0
 
-# Read services from pre-collected data
 SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_MISMATCH=0
+SELECTOR_FACTS="[]"
+AFFECTED_SERVICES="[]"
+
+mark_affected() {
+    AFFECTED_SERVICES=$(echo "$AFFECTED_SERVICES" | jq --arg s "$1" 'if any(. == $s) then . else . + [$s] end')
+}
 
 for SERVICE_NAME in $SERVICES; do
-    # Get service info from pre-collected data
     SERVICE_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$SERVICES_FILE" 2>/dev/null)
 
-    # Get service selectors
     SERVICE_SELECTORS=$(echo "$SERVICE_INFO" | jq -r '.spec.selector | to_entries | map("\(.key)=\(.value)") | join(",")')
+    SELECTOR_OBJECT=$(echo "$SERVICE_INFO" | jq -c '.spec.selector')
 
     if [[ -z "$SERVICE_SELECTORS" || "$SERVICE_SELECTORS" == "null" ]]; then
-        HAS_MISMATCH=1
+        mark_affected "$SERVICE_NAME"
         print_error "Service $SERVICE_NAME: No selector defined"
+
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" '{service: $svc, issue: "no_selector"}')
+        SELECTOR_FACTS=$(echo "$SELECTOR_FACTS" | jq --argjson f "$FACT" '. + [$f]')
         continue
     fi
 
-    # Find pods that match service selector from pre-collected data
-    # Get service selector as a proper object
-    SELECTOR_OBJECT=$(echo "$SERVICE_INFO" | jq -c '.spec.selector')
-
-    # Match pods where all service selectors are present in pod labels
     MATCHING_PODS=$(jq -r --argjson selectors "$SELECTOR_OBJECT" '
       .items[] |
       . as $pod |
@@ -40,30 +40,32 @@ for SERVICE_NAME in $SERVICES; do
     ' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
 
     if [[ -z "$MATCHING_PODS" ]]; then
-        HAS_MISMATCH=1
+        mark_affected "$SERVICE_NAME"
         print_error "Service $SERVICE_NAME: No pods match selector ($SERVICE_SELECTORS)"
 
-        # Show what pods exist with deployment_id from pre-collected data
         EXISTING_PODS=$(jq -r --arg dep_id "$DEPLOYMENT_ID" '.items[] | select(.metadata.labels.deployment_id == $dep_id) | .metadata.name' "$PODS_FILE" 2>/dev/null | tr '\n' ' ')
+        MISMATCH_FACTS="[]"
+
         if [[ -n "$EXISTING_PODS" ]]; then
             print_warning "  Existing pods with deployment_id: $EXISTING_PODS"
 
-            # Show first pod's labels for comparison
             FIRST_POD=$(echo "$EXISTING_PODS" | awk '{print $1}')
             POD_LABELS=$(jq -r --arg pod "$FIRST_POD" '.items[] | select(.metadata.name == $pod) | .metadata.labels | to_entries | map("\(.key)=\(.value)") | join(",")' "$PODS_FILE" 2>/dev/null)
             print_info "  Pod labels: $POD_LABELS"
 
-            # Check each selector against pod labels and show only mismatches
-            MISMATCHES=""
             MATCH_COUNT=0
             SELECTOR_COUNT=0
             while IFS='=' read -r key value; do
                 SELECTOR_COUNT=$((SELECTOR_COUNT + 1))
                 POD_VALUE=$(jq -r --arg pod "$FIRST_POD" --arg key "$key" '.items[] | select(.metadata.name == $pod) | .metadata.labels[$key] // "MISSING"' "$PODS_FILE" 2>/dev/null)
                 if [[ "$POD_VALUE" == "MISSING" ]]; then
-                    MISMATCHES="${MISMATCHES}    ✗ $key: selector='$value', pod=MISSING\n"
+                    MM=$(jq -nc --arg key "$key" --arg expected "$value" --arg actual "MISSING" \
+                        '{key: $key, selector_value: $expected, pod_value: $actual, kind: "missing"}')
+                    MISMATCH_FACTS=$(echo "$MISMATCH_FACTS" | jq --argjson m "$MM" '. + [$m]')
                 elif [[ "$POD_VALUE" != "$value" ]]; then
-                    MISMATCHES="${MISMATCHES}    ✗ $key: selector='$value', pod='$POD_VALUE'\n"
+                    MM=$(jq -nc --arg key "$key" --arg expected "$value" --arg actual "$POD_VALUE" \
+                        '{key: $key, selector_value: $expected, pod_value: $actual, kind: "mismatch"}')
+                    MISMATCH_FACTS=$(echo "$MISMATCH_FACTS" | jq --argjson m "$MM" '. + [$m]')
                 else
                     MATCH_COUNT=$((MATCH_COUNT + 1))
                 fi
@@ -71,35 +73,50 @@ for SERVICE_NAME in $SERVICES; do
 
             print_info "  Selector check: $MATCH_COUNT/$SELECTOR_COUNT labels match"
 
-            if [[ -n "$MISMATCHES" ]]; then
+            MISMATCH_LEN=$(echo "$MISMATCH_FACTS" | jq 'length')
+            if [[ $MISMATCH_LEN -gt 0 ]]; then
                 print_warning "  Selector mismatches:"
-                echo -e "$MISMATCHES"
-            else
-                print_warning "  All selectors match but jq query failed - checking jq logic..."
-                # Debug: try the query manually to see what happens
-                DEBUG_RESULT=$(jq --argjson selectors "$SELECTOR_OBJECT" --arg pod "$FIRST_POD" '
-                  .items[] | select(.metadata.name == $pod) |
-                  . as $p |
-                  {
-                    pod: .metadata.name,
-                    matches: ($selectors | to_entries | all(.key as $k | .value as $v |
-                      $p.metadata.labels[$k] == $v
-                    ))
-                  }
-                ' "$PODS_FILE" 2>&1)
-                print_info "  Debug result: $DEBUG_RESULT"
+                echo "$MISMATCH_FACTS" | jq -r '.[] | "    ✗ " + .key + ": selector=" + .selector_value + ", pod=" + .pod_value' | while IFS= read -r line; do
+                    print_warning "$line"
+                done
             fi
 
             print_action "Verify pod labels match service selector"
         fi
+
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" --argjson sel "$SELECTOR_OBJECT" \
+            --argjson mismatches "$MISMATCH_FACTS" \
+            --arg existing_pods "$EXISTING_PODS" \
+            '{service: $svc, issue: "no_matching_pods", selector: $sel, existing_pods_with_deployment_id: ($existing_pods | split(" ") | map(select(length > 0))), label_mismatches: $mismatches}')
+        SELECTOR_FACTS=$(echo "$SELECTOR_FACTS" | jq --argjson f "$FACT" '. + [$f]')
     else
-        POD_COUNT=$(echo "$MATCHING_PODS" | wc -w)
+        POD_COUNT=$(echo "$MATCHING_PODS" | wc -w | tr -d ' ')
         print_success "Service $SERVICE_NAME: Selector matches $POD_COUNT pod(s)"
+        FACT=$(jq -nc --arg svc "$SERVICE_NAME" --argjson sel "$SELECTOR_OBJECT" \
+            --argjson matched "$POD_COUNT" \
+            '{service: $svc, selector: $sel, matched_pod_count: $matched}')
+        SELECTOR_FACTS=$(echo "$SELECTOR_FACTS" | jq --argjson f "$FACT" '. + [$f]')
     fi
 done
 
-if [[ $HAS_MISMATCH -eq 0 ]]; then
-    update_check_result --status "success" --evidence "{}"
+SERVICE_COUNT=$(echo "$SERVICES" | wc -w | tr -d ' ')
+ISSUE_COUNT=$(echo "$AFFECTED_SERVICES" | jq 'length')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
+    EVIDENCE=$(evidence_json \
+        "All $SERVICE_COUNT service(s) match at least one pod" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson facts "$SELECTOR_FACTS" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $facts}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $SERVICE_COUNT service(s) have selector issues"
+    DETAILS=$(jq -nc \
+        --argjson facts "$SELECTOR_FACTS" \
+        --argjson count "$SERVICE_COUNT" \
+        '{service_count: $count, issue_count: ($facts | map(select(.issue != null)) | length), services: $facts}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "critical" "$AFFECTED_SERVICES" "$DETAILS" \
+        '["Verify pod labels match service selector"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/service/service_type_validation
+++ b/k8s/diagnose/service/service_type_validation
@@ -2,75 +2,114 @@
 # Check: Service Type Validation
 # Verifies service type is correctly configured
 
-# Validate services exist
 require_services || return 0
 
-# Read services from pre-collected data
 SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n' ' ')
 
-HAS_ISSUES=0
+ISSUE_FACTS="[]"
+SERVICE_FACTS="[]"
+AFFECTED_SERVICES="[]"
+
+mark_affected() {
+    AFFECTED_SERVICES=$(echo "$AFFECTED_SERVICES" | jq --arg s "$1" 'if any(. == $s) then . else . + [$s] end')
+}
 
 for SERVICE_NAME in $SERVICES; do
-    # Get service info from pre-collected data
     SERVICE_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$SERVICES_FILE" 2>/dev/null)
-
     SERVICE_TYPE=$(echo "$SERVICE_INFO" | jq -r '.spec.type')
 
     print_info "Service $SERVICE_NAME: Type=$SERVICE_TYPE"
 
+    # Per-service fact (regardless of issue)
     case "$SERVICE_TYPE" in
         ClusterIP)
             CLUSTER_IP=$(echo "$SERVICE_INFO" | jq -r '.spec.clusterIP')
             if [[ "$CLUSTER_IP" == "None" ]]; then
                 print_success "  Headless service (ClusterIP: None)"
+                SVC_FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "$SERVICE_TYPE" \
+                    '{service: $svc, type: $type, cluster_ip: "None", headless: true}')
             else
                 print_success "  Internal service with ClusterIP: $CLUSTER_IP"
+                SVC_FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "$SERVICE_TYPE" --arg ip "$CLUSTER_IP" \
+                    '{service: $svc, type: $type, cluster_ip: $ip, headless: false}')
             fi
             ;;
 
         NodePort)
-            NODE_PORTS=$(echo "$SERVICE_INFO" | jq -r '.spec.ports[] | "\(.port):\(.nodePort)"')
+            NODE_PORTS_LIST=$(echo "$SERVICE_INFO" | jq -c '[.spec.ports[] | {port: .port, node_port: .nodePort}]')
             print_success "  NodePort service exposed on:"
-            echo "$NODE_PORTS" | while IFS=':' read -r PORT NODE_PORT; do
-                print_info "    Port $PORT -> NodePort $NODE_PORT"
+            echo "$SERVICE_INFO" | jq -r '.spec.ports[] | "    Port \(.port) -> NodePort \(.nodePort)"' | while IFS= read -r line; do
+                print_info "$line"
             done
+            SVC_FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "$SERVICE_TYPE" --argjson ports "$NODE_PORTS_LIST" \
+                '{service: $svc, type: $type, node_ports: $ports}')
             ;;
 
         LoadBalancer)
             EXTERNAL_IP=$(echo "$SERVICE_INFO" | jq -r '.status.loadBalancer.ingress[0].ip // .status.loadBalancer.ingress[0].hostname // "Pending"')
 
             if [[ "$EXTERNAL_IP" == "Pending" || "$EXTERNAL_IP" == "null" ]]; then
-                HAS_ISSUES=1
+                mark_affected "$SERVICE_NAME"
                 print_warning "  LoadBalancer IP/Hostname is Pending"
                 print_info "    This may take a few minutes to provision"
 
-                # Check for events related to LoadBalancer from pre-collected data
                 LB_EVENTS=$(jq -r --arg name "$SERVICE_NAME" '.items[] | select(.involvedObject.name == $name and (.message | test("loadbalancer|external"; "i"))) | "\(.lastTimestamp) \(.message)"' "$EVENTS_FILE" 2>/dev/null | tail -n 3)
                 if [[ -n "$LB_EVENTS" ]]; then
                     print_info "    Recent events:"
                     echo "$LB_EVENTS" | sed 's/^/      /'
                 fi
                 print_action "Wait for provisioning or check cloud provider logs for errors"
+
+                FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "$SERVICE_TYPE" \
+                    '{service: $svc, type: $type, issue: "loadbalancer_pending"}')
+                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+                SVC_FACT="$FACT"
             else
                 print_success "  LoadBalancer available at: $EXTERNAL_IP"
+                SVC_FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "$SERVICE_TYPE" --arg addr "$EXTERNAL_IP" \
+                    '{service: $svc, type: $type, external_address: $addr}')
             fi
             ;;
 
         ExternalName)
             EXTERNAL_NAME=$(echo "$SERVICE_INFO" | jq -r '.spec.externalName')
             print_success "  ExternalName service pointing to: $EXTERNAL_NAME"
+            SVC_FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "$SERVICE_TYPE" --arg ext "$EXTERNAL_NAME" \
+                '{service: $svc, type: $type, external_name: $ext}')
             ;;
 
         *)
-            HAS_ISSUES=1
+            mark_affected "$SERVICE_NAME"
             print_error "  Unknown service type: $SERVICE_TYPE"
             print_action "Use valid service type (ClusterIP, NodePort, LoadBalancer, or ExternalName)"
+            FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "${SERVICE_TYPE:-null}" \
+                '{service: $svc, type: $type, issue: "unknown_service_type"}')
+            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+            SVC_FACT="$FACT"
             ;;
     esac
+    SERVICE_FACTS=$(echo "$SERVICE_FACTS" | jq --argjson f "$SVC_FACT" '. + [$f]')
 done
 
-if [[ $HAS_ISSUES -eq 0 ]]; then
-    update_check_result --status "success" --evidence "{}"
+ISSUE_COUNT=$(echo "$ISSUE_FACTS" | jq 'length')
+SERVICE_COUNT=$(echo "$SERVICES" | wc -w | tr -d ' ')
+
+if [[ $ISSUE_COUNT -eq 0 ]]; then
+    EVIDENCE=$(evidence_json \
+        "All $SERVICE_COUNT service(s) have valid types" \
+        "info" \
+        "[]" \
+        "$(jq -nc --argjson services "$SERVICE_FACTS" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $services}')" \
+        "[]")
+    update_check_result --status "success" --evidence "$EVIDENCE"
 else
-    update_check_result --status "failed" --evidence "{}"
+    SUMMARY="$ISSUE_COUNT of $SERVICE_COUNT service(s) have type issues"
+    DETAILS=$(jq -nc \
+        --argjson services "$SERVICE_FACTS" \
+        --argjson issues "$ISSUE_FACTS" \
+        --argjson count "$SERVICE_COUNT" \
+        '{service_count: $count, issue_count: ($issues | length), services: $services, issues: $issues}')
+    EVIDENCE=$(evidence_json "$SUMMARY" "warning" "$AFFECTED_SERVICES" "$DETAILS" \
+        '["Wait for provisioning or check cloud provider logs for errors"]')
+    update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/service/service_type_validation
+++ b/k8s/diagnose/service/service_type_validation
@@ -6,13 +6,10 @@ require_services || return 0
 
 SERVICES=$(jq -r '.items[].metadata.name' "$SERVICES_FILE" 2>/dev/null | tr '\n' ' ')
 
-ISSUE_FACTS="[]"
-SERVICE_FACTS="[]"
-AFFECTED_SERVICES="[]"
+ISSUE_FACTS=()
+SERVICE_FACTS=()
+AFFECTED_SERVICES=""
 
-mark_affected() {
-    AFFECTED_SERVICES=$(echo "$AFFECTED_SERVICES" | jq --arg s "$1" 'if any(. == $s) then . else . + [$s] end')
-}
 
 for SERVICE_NAME in $SERVICES; do
     SERVICE_INFO=$(jq --arg name "$SERVICE_NAME" '.items[] | select(.metadata.name == $name)' "$SERVICES_FILE" 2>/dev/null)
@@ -49,7 +46,7 @@ for SERVICE_NAME in $SERVICES; do
             EXTERNAL_IP=$(echo "$SERVICE_INFO" | jq -r '.status.loadBalancer.ingress[0].ip // .status.loadBalancer.ingress[0].hostname // "Pending"')
 
             if [[ "$EXTERNAL_IP" == "Pending" || "$EXTERNAL_IP" == "null" ]]; then
-                mark_affected "$SERVICE_NAME"
+                mark_affected AFFECTED_SERVICES "$SERVICE_NAME"
                 print_warning "  LoadBalancer IP/Hostname is Pending"
                 print_info "    This may take a few minutes to provision"
 
@@ -62,7 +59,7 @@ for SERVICE_NAME in $SERVICES; do
 
                 FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "$SERVICE_TYPE" \
                     '{service: $svc, type: $type, issue: "loadbalancer_pending"}')
-                ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+                add_fact ISSUE_FACTS "$FACT"
                 SVC_FACT="$FACT"
             else
                 print_success "  LoadBalancer available at: $EXTERNAL_IP"
@@ -79,16 +76,16 @@ for SERVICE_NAME in $SERVICES; do
             ;;
 
         *)
-            mark_affected "$SERVICE_NAME"
+            mark_affected AFFECTED_SERVICES "$SERVICE_NAME"
             print_error "  Unknown service type: $SERVICE_TYPE"
             print_action "Use valid service type (ClusterIP, NodePort, LoadBalancer, or ExternalName)"
             FACT=$(jq -nc --arg svc "$SERVICE_NAME" --arg type "${SERVICE_TYPE:-null}" \
                 '{service: $svc, type: $type, issue: "unknown_service_type"}')
-            ISSUE_FACTS=$(echo "$ISSUE_FACTS" | jq --argjson f "$FACT" '. + [$f]')
+            add_fact ISSUE_FACTS "$FACT"
             SVC_FACT="$FACT"
             ;;
     esac
-    SERVICE_FACTS=$(echo "$SERVICE_FACTS" | jq --argjson f "$SVC_FACT" '. + [$f]')
+    add_fact SERVICE_FACTS "$SVC_FACT"
 done
 
 ISSUE_COUNT=$(echo "$ISSUE_FACTS" | jq 'length')
@@ -99,17 +96,17 @@ if [[ $ISSUE_COUNT -eq 0 ]]; then
         "All $SERVICE_COUNT service(s) have valid types" \
         "info" \
         "[]" \
-        "$(jq -nc --argjson services "$SERVICE_FACTS" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $services}')" \
+        "$(jq -nc --argjson services "$(facts_to_json_array SERVICE_FACTS)" --argjson count "$SERVICE_COUNT" '{service_count: $count, services: $services}')" \
         "[]")
     update_check_result --status "success" --evidence "$EVIDENCE"
 else
     SUMMARY="$ISSUE_COUNT of $SERVICE_COUNT service(s) have type issues"
     DETAILS=$(jq -nc \
-        --argjson services "$SERVICE_FACTS" \
-        --argjson issues "$ISSUE_FACTS" \
+        --argjson services "$(facts_to_json_array SERVICE_FACTS)" \
+        --argjson issues "$(facts_to_json_array ISSUE_FACTS)" \
         --argjson count "$SERVICE_COUNT" \
         '{service_count: $count, issue_count: ($issues | length), services: $services, issues: $issues}')
-    EVIDENCE=$(evidence_json "$SUMMARY" "warning" "$AFFECTED_SERVICES" "$DETAILS" \
+    EVIDENCE=$(evidence_json "$SUMMARY" "warning" "$(set_to_json_array AFFECTED_SERVICES)" "$DETAILS" \
         '["Wait for provisioning or check cloud provider logs for errors"]')
     update_check_result --status "failed" --evidence "$EVIDENCE"
 fi

--- a/k8s/diagnose/tests/build_context.bats
+++ b/k8s/diagnose/tests/build_context.bats
@@ -25,12 +25,15 @@ setup() {
       *"app.kubernetes.io/name=aws-load-balancer-controller"*) echo '{"items":[]}' ;;
       *"app=aws-alb-ingress-controller"*) echo '{"items":[]}' ;;
       *"get pods"*)        echo '{"items":[{"metadata":{"name":"test-pod"}}]}' ;;
+      *"get deployment"*)  echo '{"items":[{"metadata":{"name":"test-deployment"}}]}' ;;
+      *"get rs"*)          echo '{"items":[{"metadata":{"name":"test-rs"}}]}' ;;
       *"get services"*)    echo '{"items":[{"metadata":{"name":"test-service"}}]}' ;;
       *"get endpoints"*)   echo '{"items":[]}' ;;
       *"get ingress"*)     echo '{"items":[]}' ;;
       *"get secrets"*)     echo '{"items":[]}' ;;
       *"get ingressclass"*) echo '{"items":[]}' ;;
       *"get events"*)      echo '{"items":[]}' ;;
+      *"describe pod"*)    echo "Pod describe output" ;;
       *"logs"*)            echo "log line 1" ;;
       *)                   echo '{"items":[]}' ;;
     esac
@@ -99,13 +102,19 @@ run_build_context() {
 
   assert_directory_exists "$NP_OUTPUT_DIR/data"
   assert_directory_exists "$NP_OUTPUT_DIR/data/alb_controller_logs"
+  assert_directory_exists "$POD_LOGS_DIR"
+  assert_directory_exists "$POD_DESCRIBE_DIR"
 
   # All resource files should exist and be valid JSON
-  for file in "$PODS_FILE" "$SERVICES_FILE" "$ENDPOINTS_FILE" "$INGRESSES_FILE" \
-              "$SECRETS_FILE" "$INGRESSCLASSES_FILE" "$EVENTS_FILE" "$ALB_CONTROLLER_PODS_FILE"; do
+  for file in "$PODS_FILE" "$DEPLOYMENTS_FILE" "$REPLICASETS_FILE" "$SERVICES_FILE" \
+              "$ENDPOINTS_FILE" "$INGRESSES_FILE" "$SECRETS_FILE" "$INGRESSCLASSES_FILE" \
+              "$EVENTS_FILE" "$ALB_CONTROLLER_PODS_FILE"; do
     assert_file_exists "$file"
     jq . "$file" >/dev/null
   done
+
+  # problematic_pods.txt is plain text, just assert it exists
+  assert_file_exists "$PROBLEMATIC_PODS_FILE"
 }
 
 @test "build_context: secrets.json excludes sensitive data field" {
@@ -182,4 +191,265 @@ run_build_context() {
   assert_file_exists "$ALB_CONTROLLER_LOGS_DIR/alb-controller-pod.log"
   log_content=$(cat "$ALB_CONTROLLER_LOGS_DIR/alb-controller-pod.log")
   assert_contains "$log_content" "controller log line"
+}
+
+# =============================================================================
+# Problematic Pod Detection
+# =============================================================================
+@test "build_context: healthy running pod is not flagged as problematic" {
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"healthy-pod"},
+          "spec":{"containers":[{"name":"app"}]},
+          "status":{
+            "phase":"Running",
+            "conditions":[{"type":"Ready","status":"True"}],
+            "containerStatuses":[{"name":"app","restartCount":0,"state":{"running":{}},"lastState":{}}]
+          }
+        }]}'
+        ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  problematic=$(cat "$PROBLEMATIC_PODS_FILE")
+  assert_empty "$problematic"
+}
+
+@test "build_context: pod in CrashLoopBackOff is flagged as problematic" {
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"crash-pod"},
+          "spec":{"containers":[{"name":"app"}]},
+          "status":{
+            "phase":"Running",
+            "conditions":[{"type":"Ready","status":"False"}],
+            "containerStatuses":[{"name":"app","restartCount":5,"state":{"waiting":{"reason":"CrashLoopBackOff"}},"lastState":{"terminated":{"exitCode":1}}}]
+          }
+        }]}'
+        ;;
+      *"describe pod crash-pod"*) echo "describe output for crash-pod" ;;
+      *"logs"*"crash-pod"*"--previous"*) echo "previous crash log" ;;
+      *"logs"*"crash-pod"*) echo "current log" ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  problematic=$(cat "$PROBLEMATIC_PODS_FILE")
+  assert_contains "$problematic" "crash-pod"
+}
+
+@test "build_context: pod in Pending phase is flagged as problematic" {
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"pending-pod"},
+          "spec":{"containers":[{"name":"app"}]},
+          "status":{"phase":"Pending"}
+        }]}'
+        ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  problematic=$(cat "$PROBLEMATIC_PODS_FILE")
+  assert_contains "$problematic" "pending-pod"
+}
+
+@test "build_context: pod with terminating deletionTimestamp is flagged as problematic" {
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"terminating-pod","deletionTimestamp":"2026-01-01T00:00:00Z"},
+          "spec":{"containers":[{"name":"app"}]},
+          "status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}],"containerStatuses":[{"name":"app","restartCount":0,"state":{"running":{}},"lastState":{}}]}
+        }]}'
+        ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  problematic=$(cat "$PROBLEMATIC_PODS_FILE")
+  assert_contains "$problematic" "terminating-pod"
+}
+
+@test "build_context: pod with failed init container is flagged as problematic" {
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"init-fail-pod"},
+          "spec":{"initContainers":[{"name":"init-db"}],"containers":[{"name":"app"}]},
+          "status":{
+            "phase":"Pending",
+            "initContainerStatuses":[{"name":"init-db","restartCount":3,"state":{"waiting":{"reason":"CrashLoopBackOff"}},"lastState":{"terminated":{"exitCode":1}}}]
+          }
+        }]}'
+        ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  problematic=$(cat "$PROBLEMATIC_PODS_FILE")
+  assert_contains "$problematic" "init-fail-pod"
+}
+
+# =============================================================================
+# Pod Logs and Describe Capture
+# =============================================================================
+@test "build_context: captures describe and current logs for problematic pod" {
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"crash-pod"},
+          "spec":{"containers":[{"name":"app"}]},
+          "status":{
+            "phase":"Running",
+            "containerStatuses":[{"name":"app","restartCount":2,"state":{"waiting":{"reason":"CrashLoopBackOff"}},"lastState":{"terminated":{"exitCode":1}}}]
+          }
+        }]}'
+        ;;
+      *"describe pod crash-pod"*) echo "describe output for crash-pod" ;;
+      *"logs"*"crash-pod"*"--previous"*) echo "previous crash log" ;;
+      *"logs"*"crash-pod"*) echo "current log line" ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  assert_file_exists "$POD_DESCRIBE_DIR/crash-pod.txt"
+  describe_content=$(cat "$POD_DESCRIBE_DIR/crash-pod.txt")
+  assert_contains "$describe_content" "describe output for crash-pod"
+
+  assert_file_exists "$POD_LOGS_DIR/crash-pod.app.log"
+  current_log=$(cat "$POD_LOGS_DIR/crash-pod.app.log")
+  assert_contains "$current_log" "current log line"
+
+  assert_file_exists "$POD_LOGS_DIR/crash-pod.app.previous.log"
+  previous_log=$(cat "$POD_LOGS_DIR/crash-pod.app.previous.log")
+  assert_contains "$previous_log" "previous crash log"
+}
+
+@test "build_context: skips empty previous logs (container never crashed before)" {
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"new-pod"},
+          "spec":{"containers":[{"name":"app"}]},
+          "status":{
+            "phase":"Pending",
+            "containerStatuses":[{"name":"app","restartCount":0,"state":{"waiting":{"reason":"ImagePullBackOff"}},"lastState":{}}]
+          }
+        }]}'
+        ;;
+      *"describe pod new-pod"*) echo "describe output" ;;
+      *"logs"*"new-pod"*"--previous"*) return 1 ;;
+      *"logs"*"new-pod"*) echo "current log" ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  # Current log should be saved
+  assert_file_exists "$POD_LOGS_DIR/new-pod.app.log"
+
+  # Previous log should NOT exist (kubectl returned no output)
+  [ ! -f "$POD_LOGS_DIR/new-pod.app.previous.log" ]
+}
+
+@test "build_context: captures logs for all containers including init containers" {
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"multi-container-pod"},
+          "spec":{
+            "initContainers":[{"name":"init-db"}],
+            "containers":[{"name":"app"},{"name":"sidecar"}]
+          },
+          "status":{
+            "phase":"Pending",
+            "initContainerStatuses":[{"name":"init-db","restartCount":1,"state":{"waiting":{"reason":"CrashLoopBackOff"}},"lastState":{"terminated":{"exitCode":1}}}]
+          }
+        }]}'
+        ;;
+      *"describe pod multi-container-pod"*) echo "describe output" ;;
+      *"logs"*"-c init-db"*"--previous"*) echo "init previous" ;;
+      *"logs"*"-c init-db"*) echo "init current" ;;
+      *"logs"*"-c app"*"--previous"*) return 1 ;;
+      *"logs"*"-c app"*) echo "app current" ;;
+      *"logs"*"-c sidecar"*"--previous"*) return 1 ;;
+      *"logs"*"-c sidecar"*) echo "sidecar current" ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  # All three containers' current logs should exist
+  assert_file_exists "$POD_LOGS_DIR/multi-container-pod.init-db.log"
+  assert_file_exists "$POD_LOGS_DIR/multi-container-pod.app.log"
+  assert_file_exists "$POD_LOGS_DIR/multi-container-pod.sidecar.log"
+
+  # Only init-db has a previous log
+  assert_file_exists "$POD_LOGS_DIR/multi-container-pod.init-db.previous.log"
+  [ ! -f "$POD_LOGS_DIR/multi-container-pod.app.previous.log" ]
+  [ ! -f "$POD_LOGS_DIR/multi-container-pod.sidecar.previous.log" ]
+}
+
+@test "build_context: respects POD_LOG_TAIL_LINES env var" {
+  export POD_LOG_TAIL_LINES=42
+
+  # Capture the kubectl invocation to verify --tail value
+  kubectl() {
+    case "$*" in
+      *"get pods"*)
+        echo '{"items":[{
+          "metadata":{"name":"crash-pod"},
+          "spec":{"containers":[{"name":"app"}]},
+          "status":{"phase":"Pending","containerStatuses":[{"name":"app","restartCount":1,"state":{"waiting":{"reason":"ImagePullBackOff"}},"lastState":{}}]}
+        }]}'
+        ;;
+      *"logs"*"--tail=42"*) echo "tail-42-honored" ;;
+      *"logs"*) echo "WRONG: tail value was not 42" ;;
+      *"describe"*) echo "describe" ;;
+      *) echo '{"items":[]}' ;;
+    esac
+  }
+  export -f kubectl
+
+  run_build_context
+
+  log_content=$(cat "$POD_LOGS_DIR/crash-pod.app.log")
+  assert_contains "$log_content" "tail-42-honored"
+
+  unset POD_LOG_TAIL_LINES
 }

--- a/k8s/diagnose/tests/diagnose_utils.bats
+++ b/k8s/diagnose/tests/diagnose_utils.bats
@@ -350,7 +350,7 @@ strip_ansi() {
 # =============================================================================
 # update_check_result - Log Limits
 # =============================================================================
-@test "update_check_result: limits logs to 20 lines" {
+@test "update_check_result: limits logs to 20 lines by default" {
   for i in {1..30}; do
     echo "log line $i" >> "$SCRIPT_LOG_FILE"
   done
@@ -359,6 +359,33 @@ strip_ansi() {
 
   logs_count=$(jq -r '.logs | length' "$SCRIPT_OUTPUT_FILE")
   [ "$logs_count" -le 20 ]
+}
+
+@test "update_check_result: --log-tail-lines overrides the default cap" {
+  for i in {1..100}; do
+    echo "log line $i" >> "$SCRIPT_LOG_FILE"
+  done
+
+  update_check_result --status "success" --evidence "{}" --log-tail-lines 80
+
+  logs_count=$(jq -r '.logs | length' "$SCRIPT_OUTPUT_FILE")
+  [ "$logs_count" = "80" ]
+  # Last entry should be the most recent line (line 100), oldest in window is line 21
+  [ "$(jq -r '.logs[-1]' "$SCRIPT_OUTPUT_FILE")" = "log line 100" ]
+  [ "$(jq -r '.logs[0]' "$SCRIPT_OUTPUT_FILE")" = "log line 21" ]
+}
+
+@test "update_check_result: --log-tail-lines below total preserves the most recent N lines" {
+  for i in {1..10}; do
+    echo "log line $i" >> "$SCRIPT_LOG_FILE"
+  done
+
+  update_check_result --status "success" --evidence "{}" --log-tail-lines 5
+
+  logs_count=$(jq -r '.logs | length' "$SCRIPT_OUTPUT_FILE")
+  [ "$logs_count" = "5" ]
+  [ "$(jq -r '.logs[0]' "$SCRIPT_OUTPUT_FILE")" = "log line 6" ]
+  [ "$(jq -r '.logs[-1]' "$SCRIPT_OUTPUT_FILE")" = "log line 10" ]
 }
 
 # =============================================================================

--- a/k8s/diagnose/tests/diagnose_utils.bats
+++ b/k8s/diagnose/tests/diagnose_utils.bats
@@ -78,6 +78,66 @@ strip_ansi() {
 }
 
 # =============================================================================
+# evidence_json
+# =============================================================================
+@test "evidence_json: builds full schema from all arguments" {
+  result=$(evidence_json "Test summary" "critical" '["pod-1","pod-2"]' '{"k":"v"}' '["fix it"]')
+
+  summary=$(echo "$result" | jq -r '.summary')
+  assert_equal "$summary" "Test summary"
+
+  severity=$(echo "$result" | jq -r '.severity')
+  assert_equal "$severity" "critical"
+
+  affected=$(echo "$result" | jq -c '.affected')
+  assert_equal "$affected" '["pod-1","pod-2"]'
+
+  details_k=$(echo "$result" | jq -r '.details.k')
+  assert_equal "$details_k" "v"
+
+  action_0=$(echo "$result" | jq -r '.suggested_actions[0]')
+  assert_equal "$action_0" "fix it"
+}
+
+@test "evidence_json: applies sane defaults for empty optional fields" {
+  result=$(evidence_json "Quick check" "info" "" "" "")
+
+  affected=$(echo "$result" | jq -c '.affected')
+  assert_equal "$affected" "[]"
+
+  details=$(echo "$result" | jq -c '.details')
+  assert_equal "$details" "{}"
+
+  actions=$(echo "$result" | jq -c '.suggested_actions')
+  assert_equal "$actions" "[]"
+}
+
+@test "evidence_json: emits valid JSON consumable by update_check_result" {
+  result=$(evidence_json "S" "warning" '["x"]' '{"a":1}' '["b"]')
+
+  # Should be parseable by jq without errors
+  parsed=$(echo "$result" | jq -c .)
+  assert_equal "$parsed" '{"summary":"S","severity":"warning","affected":["x"],"details":{"a":1},"suggested_actions":["b"]}'
+}
+
+# =============================================================================
+# exit_code_meaning
+# =============================================================================
+@test "exit_code_meaning: maps known codes" {
+  assert_equal "$(exit_code_meaning 0)"   "Clean exit (container finished successfully)"
+  assert_equal "$(exit_code_meaning 1)"   "Application error"
+  assert_equal "$(exit_code_meaning 137)" "OOMKilled (out of memory)"
+  assert_equal "$(exit_code_meaning 139)" "SIGSEGV (segmentation fault)"
+  assert_equal "$(exit_code_meaning 143)" "SIGTERM (graceful termination)"
+}
+
+@test "exit_code_meaning: returns Unknown for unmapped codes" {
+  assert_equal "$(exit_code_meaning 42)"    "Unknown"
+  assert_equal "$(exit_code_meaning N/A)"   "Unknown"
+  assert_equal "$(exit_code_meaning '')"    "Unknown"
+}
+
+# =============================================================================
 # require_resources
 # =============================================================================
 @test "require_resources: returns 0 when resources exist" {
@@ -95,6 +155,41 @@ strip_ansi() {
   [ "$status" -eq 1 ]
   local clean=$(strip_ansi "$output")
   assert_contains "$clean" "⚠ No pods found with labels app=test in namespace default, check was skipped."
+}
+
+@test "require_resources: emits skipped evidence following the schema" {
+  # Capture the evidence passed to update_check_result
+  local captured_evidence_file="$(mktemp)"
+  update_check_result() {
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --evidence) echo "$2" > "$captured_evidence_file"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    return 0
+  }
+  export -f update_check_result
+
+  require_resources "pods" "" "scope_id=999" "production" || true
+
+  # Validate the schema of the captured evidence
+  local evidence
+  evidence=$(cat "$captured_evidence_file")
+
+  severity=$(echo "$evidence" | jq -r '.severity')
+  assert_equal "$severity" "info"
+
+  summary=$(echo "$evidence" | jq -r '.summary')
+  assert_contains "$summary" "skipped"
+
+  resource_type=$(echo "$evidence" | jq -r '.details.resource_type')
+  assert_equal "$resource_type" "pods"
+
+  label_selector=$(echo "$evidence" | jq -r '.details.label_selector')
+  assert_equal "$label_selector" "scope_id=999"
+
+  rm -f "$captured_evidence_file"
 }
 
 # =============================================================================

--- a/k8s/diagnose/tests/evidence_schema.bats
+++ b/k8s/diagnose/tests/evidence_schema.bats
@@ -268,3 +268,175 @@ EOF
   [[ "$affected" == '["my-ing"]' ]] || return 1
 }
 
+# =============================================================================
+# Embedded logs in evidence (Fase C — for AI post-mortem consumption)
+# =============================================================================
+
+# Helper: prepare a fake POD_LOGS_DIR with current/previous logs for a given pod+container
+setup_pod_logs() {
+  local pod="$1" container="$2" current="$3" previous="$4"
+  export POD_LOGS_DIR="${POD_LOGS_DIR:-$(mktemp -d)}"
+  echo "$current"  > "$POD_LOGS_DIR/${pod}.${container}.log"
+  if [[ -n "$previous" ]]; then
+    echo "$previous" > "$POD_LOGS_DIR/${pod}.${container}.previous.log"
+  fi
+}
+
+@test "logs: read_log_tail returns [] when POD_LOGS_DIR unset or file missing" {
+  unset POD_LOGS_DIR
+  result=$(read_log_tail "any-pod" "any-container" "current")
+  [[ "$result" == "[]" ]] || { echo "expected [], got $result"; return 1; }
+
+  export POD_LOGS_DIR="$(mktemp -d)"
+  result=$(read_log_tail "missing-pod" "missing-container" "previous")
+  [[ "$result" == "[]" ]] || { echo "expected [], got $result"; return 1; }
+}
+
+@test "logs: read_log_tail returns lines as JSON array when log exists" {
+  export POD_LOGS_DIR="$(mktemp -d)"
+  printf 'line1\nline2\nline3\n' > "$POD_LOGS_DIR/p.c.log"
+
+  result=$(read_log_tail "p" "c" "current")
+  count=$(echo "$result" | jq 'length')
+  [[ "$count" == "3" ]] || { echo "expected 3 lines, got $count"; return 1; }
+
+  first=$(echo "$result" | jq -r '.[0]')
+  [[ "$first" == "line1" ]] || { echo "expected line1, got $first"; return 1; }
+}
+
+@test "logs: read_log_tail respects EVIDENCE_LOG_TAIL_LINES" {
+  export POD_LOGS_DIR="$(mktemp -d)"
+  for i in $(seq 1 100); do echo "line $i"; done > "$POD_LOGS_DIR/p.c.log"
+
+  EVIDENCE_LOG_TAIL_LINES=5 result=$(read_log_tail "p" "c" "current")
+  count=$(echo "$result" | jq 'length')
+  [[ "$count" == "5" ]] || { echo "expected 5 lines, got $count"; return 1; }
+
+  # Last 5 lines should be 96..100
+  last=$(echo "$result" | jq -r '.[-1]')
+  [[ "$last" == "line 100" ]] || { echo "expected 'line 100', got '$last'"; return 1; }
+}
+
+@test "logs: container_crash_detection embeds previous logs in CrashLoopBackOff fact" {
+  reset_output
+  setup_pod_logs "crash-pod" "app" "" "Caused by: NullPointerException at line 42"
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items":[{
+    "metadata":{"name":"crash-pod"},
+    "status":{"containerStatuses":[{"name":"app","restartCount":5,"state":{"waiting":{"reason":"CrashLoopBackOff"}},"lastState":{"terminated":{"exitCode":1,"reason":"Error"}}}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/container_crash_detection" || true
+
+  prev_logs=$(jq -c '.evidence.details.crash_loop_back_off[0].previous_logs' "$SCRIPT_OUTPUT_FILE")
+  [[ "$prev_logs" != "[]" && "$prev_logs" != "null" ]] || { echo "expected non-empty previous_logs, got $prev_logs"; return 1; }
+
+  contains=$(echo "$prev_logs" | jq -r '.[] | select(test("NullPointerException"))' | head -1)
+  [[ -n "$contains" ]] || { echo "expected NullPointerException in logs, got $prev_logs"; return 1; }
+}
+
+@test "logs: memory_limits_check embeds previous logs in OOMKilled fact" {
+  reset_output
+  setup_pod_logs "oom-pod" "app" "" "java.lang.OutOfMemoryError: Java heap space"
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items":[{
+    "metadata":{"name":"oom-pod"},
+    "spec":{"containers":[{"name":"app","resources":{"limits":{"memory":"128Mi"}}}]},
+    "status":{"containerStatuses":[{"name":"app","lastState":{"terminated":{"reason":"OOMKilled","exitCode":137}}}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/memory_limits_check" || true
+
+  prev_logs=$(jq -c '.evidence.details.oom_killed[0].previous_logs' "$SCRIPT_OUTPUT_FILE")
+  contains=$(echo "$prev_logs" | jq -r '.[] | select(test("OutOfMemoryError"))' | head -1)
+  [[ -n "$contains" ]] || { echo "expected OutOfMemoryError in OOM logs, got $prev_logs"; return 1; }
+}
+
+@test "logs: container_port_health embeds current logs in port_not_listening issue" {
+  # The script needs nc + timeout to exercise the connectivity-fail path. On
+  # macOS dev hosts timeout (GNU coreutils) is not in PATH by default — skip.
+  command -v nc >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1 || \
+    skip "nc + timeout required to exercise this path"
+
+  reset_output
+  setup_pod_logs "broken-pod" "app" "ERROR: failed to bind to 0.0.0.0:8080: permission denied" ""
+  # Pick a port that's almost certainly not listening on 127.0.0.1
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items":[{
+    "metadata":{"name":"broken-pod"},
+    "spec":{"containers":[{"name":"app","ports":[{"containerPort":59999}]}]},
+    "status":{"phase":"Running","podIP":"127.0.0.1","containerStatuses":[{"name":"app","ready":true,"state":{"running":{}},"restartCount":0}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/container_port_health" || true
+
+  issue_logs=$(jq -c '.evidence.details.issues[0].container_logs // empty' "$SCRIPT_OUTPUT_FILE")
+  [[ -n "$issue_logs" && "$issue_logs" != "null" ]] || { echo "expected container_logs in issue"; cat "$SCRIPT_OUTPUT_FILE"; return 1; }
+
+  contains=$(echo "$issue_logs" | jq -r '.[] | select(test("failed to bind"))' | head -1)
+  [[ -n "$contains" ]] || { echo "expected 'failed to bind' in logs, got $issue_logs"; return 1; }
+}
+
+@test "logs: pod_readiness embeds current logs only for stuck (not_ready) pods" {
+  # not_ready (failure path) → should embed logs
+  reset_output
+  setup_pod_logs "stuck-pod" "app" "INFO: connecting to db... still trying" ""
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items":[{
+    "metadata":{"name":"stuck-pod"},
+    "spec":{"containers":[{"name":"app"}]},
+    "status":{"phase":"Running","conditions":[{"type":"Ready","status":"False","reason":"ContainersNotReady"}],"containerStatuses":[{"name":"app","ready":false,"state":{"running":{}},"restartCount":0}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/pod_readiness" || true
+
+  pod_state=$(jq -r '.evidence.details.pods[0].state' "$SCRIPT_OUTPUT_FILE")
+  [[ "$pod_state" == "not_ready" ]] || { echo "expected state=not_ready, got $pod_state"; return 1; }
+
+  pod_logs=$(jq -c '.evidence.details.pods[0].container_logs' "$SCRIPT_OUTPUT_FILE")
+  contains=$(echo "$pod_logs" | jq -r '.[].current_logs[] | select(test("connecting to db"))' | head -1)
+  [[ -n "$contains" ]] || { echo "expected 'connecting to db' in logs, got $pod_logs"; return 1; }
+
+  # starting (warning path) → should NOT embed logs (avoid noise during normal startup)
+  reset_output
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items":[{
+    "metadata":{"name":"starting-pod"},
+    "spec":{"containers":[{"name":"app"}]},
+    "status":{"phase":"Pending","conditions":[{"type":"Ready","status":"False"}],"containerStatuses":[{"name":"app","ready":false,"state":{"waiting":{"reason":"ContainerCreating"}}}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/pod_readiness" || true
+
+  starting_logs=$(jq -c '.evidence.details.pods[0].container_logs' "$SCRIPT_OUTPUT_FILE")
+  [[ "$starting_logs" == "[]" ]] || { echo "expected empty container_logs for starting pod, got $starting_logs"; return 1; }
+}
+
+@test "logs: success path does not embed logs (keeps payload light)" {
+  reset_output
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items":[{
+    "metadata":{"name":"happy-pod"},
+    "spec":{"containers":[{"name":"app"}]},
+    "status":{"phase":"Running","conditions":[{"type":"Ready","status":"True"}],"containerStatuses":[{"name":"app","ready":true,"state":{"running":{}},"restartCount":0}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/container_crash_detection" || true
+
+  details=$(jq -c '.evidence.details' "$SCRIPT_OUTPUT_FILE")
+  # Success details should not have crash_loop_back_off populated with logs
+  has_logs=$(echo "$details" | jq -r '.. | objects | select(has("previous_logs") or has("current_logs")) | "yes"' | head -1)
+  [[ -z "$has_logs" ]] || { echo "expected no logs in success evidence, got: $details"; return 1; }
+}

--- a/k8s/diagnose/tests/evidence_schema.bats
+++ b/k8s/diagnose/tests/evidence_schema.bats
@@ -131,6 +131,17 @@ NETWORKING_CHECKS_REQUIRE_INGRESSES=(
   done
 }
 
+@test "schema: logs/application_log_evidence emits valid skipped evidence when no snapshot" {
+  reset_output
+  # PROBLEMATIC_PODS_FILE intentionally not set — the check must degrade gracefully.
+  unset PROBLEMATIC_PODS_FILE
+  source "$BATS_TEST_DIRNAME/../logs/application_log_evidence" || true
+  assert_evidence_schema "logs/application_log_evidence (skipped)"
+
+  status=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
+  [[ "$status" == "skipped" ]] || { echo "expected skipped, got $status"; return 1; }
+}
+
 # =============================================================================
 # Schema validation: failed path for "no resources" existence checks
 # (these don't use require_*; they emit failed evidence directly)

--- a/k8s/diagnose/tests/evidence_schema.bats
+++ b/k8s/diagnose/tests/evidence_schema.bats
@@ -1,0 +1,270 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Cross-cutting schema validation for all migrated checks.
+# Verifies every check writes evidence following the documented schema:
+#   { summary, severity, affected, details, suggested_actions }
+# =============================================================================
+
+setup() {
+  export PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  source "$PROJECT_ROOT/testing/assertions.sh"
+  source "$BATS_TEST_DIRNAME/../utils/diagnose_utils"
+
+  export NAMESPACE="test-ns"
+  export LABEL_SELECTOR="app=test"
+  export SCOPE_LABEL_SELECTOR="scope_id=123"
+  export DEPLOYMENT_ID="deploy-1"
+  export NP_OUTPUT_DIR="$(mktemp -d)"
+  export SCRIPT_OUTPUT_FILE="$(mktemp)"
+  export SCRIPT_LOG_FILE="$(mktemp)"
+  echo '{"status":"pending","evidence":{},"logs":[]}' > "$SCRIPT_OUTPUT_FILE"
+
+  # Set up empty data files so every check can require_*
+  export PODS_FILE="$(mktemp)"
+  export SERVICES_FILE="$(mktemp)"
+  export ENDPOINTS_FILE="$(mktemp)"
+  export INGRESSES_FILE="$(mktemp)"
+  export SECRETS_FILE="$(mktemp)"
+  export INGRESSCLASSES_FILE="$(mktemp)"
+  export EVENTS_FILE="$(mktemp)"
+  export ALB_CONTROLLER_PODS_FILE="$(mktemp)"
+  export ALB_CONTROLLER_LOGS_DIR="$(mktemp -d)"
+  for f in "$PODS_FILE" "$SERVICES_FILE" "$ENDPOINTS_FILE" "$INGRESSES_FILE" \
+           "$SECRETS_FILE" "$INGRESSCLASSES_FILE" "$EVENTS_FILE" "$ALB_CONTROLLER_PODS_FILE"; do
+    echo '{"items":[]}' > "$f"
+  done
+
+  kubectl() { return 0; }
+  export -f kubectl
+}
+
+teardown() {
+  rm -rf "$NP_OUTPUT_DIR" "$ALB_CONTROLLER_LOGS_DIR"
+  rm -f "$SCRIPT_OUTPUT_FILE" "$SCRIPT_LOG_FILE" "$PODS_FILE" "$SERVICES_FILE" \
+        "$ENDPOINTS_FILE" "$INGRESSES_FILE" "$SECRETS_FILE" "$INGRESSCLASSES_FILE" \
+        "$EVENTS_FILE" "$ALB_CONTROLLER_PODS_FILE"
+  unset -f kubectl
+}
+
+reset_output() {
+  echo '{"status":"pending","evidence":{},"logs":[]}' > "$SCRIPT_OUTPUT_FILE"
+}
+
+# Assert that the evidence object on $SCRIPT_OUTPUT_FILE has the canonical schema:
+#   summary (string), severity in {critical, warning, info},
+#   affected (array), details (object), suggested_actions (array)
+assert_evidence_schema() {
+  local check_name="$1"
+
+  local summary severity affected_kind details_kind actions_kind
+  summary=$(jq -r '.evidence.summary // empty' "$SCRIPT_OUTPUT_FILE")
+  severity=$(jq -r '.evidence.severity // empty' "$SCRIPT_OUTPUT_FILE")
+  affected_kind=$(jq -r '.evidence.affected | type' "$SCRIPT_OUTPUT_FILE")
+  details_kind=$(jq -r '.evidence.details | type' "$SCRIPT_OUTPUT_FILE")
+  actions_kind=$(jq -r '.evidence.suggested_actions | type' "$SCRIPT_OUTPUT_FILE")
+
+  [[ -n "$summary" ]] || {
+    echo "[$check_name] missing evidence.summary"
+    cat "$SCRIPT_OUTPUT_FILE"
+    return 1
+  }
+
+  case "$severity" in
+    critical|warning|info) ;;
+    *) echo "[$check_name] invalid severity: '$severity'"; return 1 ;;
+  esac
+
+  [[ "$affected_kind" == "array" ]] || { echo "[$check_name] evidence.affected must be array, got $affected_kind"; return 1; }
+  [[ "$details_kind"  == "object" ]] || { echo "[$check_name] evidence.details must be object, got $details_kind"; return 1; }
+  [[ "$actions_kind"  == "array" ]] || { echo "[$check_name] evidence.suggested_actions must be array, got $actions_kind"; return 1; }
+}
+
+# =============================================================================
+# Schema validation: skipped path (require_*)
+# All checks that call require_pods/services/ingresses must produce schema
+# evidence when the resource list is empty.
+# =============================================================================
+SCOPE_CHECKS_REQUIRE_PODS=(
+  image_pull_status memory_limits_check resource_availability storage_mounting
+  container_port_health health_probe_endpoints pod_readiness container_crash_detection
+)
+
+SERVICE_CHECKS_REQUIRE_SERVICES=(
+  service_selector_match service_endpoints service_port_configuration service_type_validation
+)
+
+NETWORKING_CHECKS_REQUIRE_INGRESSES=(
+  ingress_class_validation ingress_host_rules ingress_backend_service
+  ingress_tls_configuration ingress_controller_sync alb_capacity_check
+)
+
+@test "schema: scope checks emit valid skipped evidence when no pods" {
+  for check in "${SCOPE_CHECKS_REQUIRE_PODS[@]}"; do
+    reset_output
+    source "$BATS_TEST_DIRNAME/../scope/$check" || true
+    assert_evidence_schema "scope/$check (skipped)"
+
+    status=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
+    [[ "$status" == "skipped" ]] || { echo "scope/$check expected status=skipped, got $status"; return 1; }
+  done
+}
+
+@test "schema: service checks emit valid skipped evidence when no services" {
+  for check in "${SERVICE_CHECKS_REQUIRE_SERVICES[@]}"; do
+    reset_output
+    source "$BATS_TEST_DIRNAME/../service/$check" || true
+    assert_evidence_schema "service/$check (skipped)"
+
+    status=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
+    [[ "$status" == "skipped" ]] || { echo "service/$check expected status=skipped, got $status"; return 1; }
+  done
+}
+
+@test "schema: networking checks emit valid skipped evidence when no ingresses" {
+  for check in "${NETWORKING_CHECKS_REQUIRE_INGRESSES[@]}"; do
+    reset_output
+    source "$BATS_TEST_DIRNAME/../networking/$check" || true
+    assert_evidence_schema "networking/$check (skipped)"
+
+    status=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
+    [[ "$status" == "skipped" ]] || { echo "networking/$check expected status=skipped, got $status"; return 1; }
+  done
+}
+
+# =============================================================================
+# Schema validation: failed path for "no resources" existence checks
+# (these don't use require_*; they emit failed evidence directly)
+# =============================================================================
+@test "schema: pod_existence emits valid failed evidence when no pods" {
+  reset_output
+  echo '{"items":[]}' > "$PODS_FILE"
+  source "$BATS_TEST_DIRNAME/../scope/pod_existence" || true
+  assert_evidence_schema "scope/pod_existence (failed)"
+
+  status=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
+  [[ "$status" == "failed" ]] || { echo "expected failed, got $status"; return 1; }
+
+  severity=$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")
+  [[ "$severity" == "critical" ]] || { echo "expected critical, got $severity"; return 1; }
+}
+
+@test "schema: service_existence emits valid failed evidence when no services" {
+  reset_output
+  echo '{"items":[]}' > "$SERVICES_FILE"
+  source "$BATS_TEST_DIRNAME/../service/service_existence" || true
+  assert_evidence_schema "service/service_existence (failed)"
+
+  status=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
+  [[ "$status" == "failed" ]] || return 1
+}
+
+@test "schema: ingress_existence emits valid failed evidence when no ingresses" {
+  reset_output
+  echo '{"items":[]}' > "$INGRESSES_FILE"
+  source "$BATS_TEST_DIRNAME/../networking/ingress_existence" || true
+  assert_evidence_schema "networking/ingress_existence (failed)"
+
+  status=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
+  [[ "$status" == "failed" ]] || return 1
+}
+
+# =============================================================================
+# Schema validation: success path for existence checks
+# =============================================================================
+@test "schema: existence checks emit valid info evidence when resources exist" {
+  # pod_existence
+  reset_output
+  echo '{"items":[{"metadata":{"name":"p1"}}]}' > "$PODS_FILE"
+  source "$BATS_TEST_DIRNAME/../scope/pod_existence" || true
+  assert_evidence_schema "scope/pod_existence (success)"
+  [[ "$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")" == "info" ]] || return 1
+
+  # service_existence
+  reset_output
+  echo '{"items":[{"metadata":{"name":"s1"}}]}' > "$SERVICES_FILE"
+  source "$BATS_TEST_DIRNAME/../service/service_existence" || true
+  assert_evidence_schema "service/service_existence (success)"
+  [[ "$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")" == "info" ]] || return 1
+
+  # ingress_existence
+  reset_output
+  echo '{"items":[{"metadata":{"name":"i1"},"spec":{"rules":[]}}]}' > "$INGRESSES_FILE"
+  source "$BATS_TEST_DIRNAME/../networking/ingress_existence" || true
+  assert_evidence_schema "networking/ingress_existence (success)"
+  [[ "$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")" == "info" ]] || return 1
+}
+
+# =============================================================================
+# A few targeted "critical" path checks with realistic failure data
+# =============================================================================
+@test "schema: image_pull_status emits valid critical evidence with affected pods" {
+  reset_output
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items": [{
+    "metadata": {"name": "p1"},
+    "spec": {"containers":[{"name":"app","image":"foo:bar"}]},
+    "status": {"containerStatuses":[{"name":"app","state":{"waiting":{"reason":"ImagePullBackOff","message":"pull failed"}}}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/image_pull_status" || true
+  assert_evidence_schema "scope/image_pull_status (failed)"
+
+  [[ "$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")" == "failed" ]] || return 1
+  [[ "$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")" == "critical" ]] || return 1
+  affected=$(jq -c '.evidence.affected' "$SCRIPT_OUTPUT_FILE")
+  [[ "$affected" == '["p1"]' ]] || { echo "expected affected=[p1], got $affected"; return 1; }
+}
+
+@test "schema: memory_limits_check emits valid critical evidence on OOMKilled" {
+  reset_output
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items": [{
+    "metadata": {"name": "oom-pod"},
+    "spec": {"containers":[{"name":"app","resources":{"limits":{"memory":"128Mi"},"requests":{"memory":"64Mi"}}}]},
+    "status": {"containerStatuses":[{"name":"app","lastState":{"terminated":{"reason":"OOMKilled","exitCode":137}}}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/memory_limits_check" || true
+  assert_evidence_schema "scope/memory_limits_check (failed)"
+
+  [[ "$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")" == "critical" ]] || return 1
+  oom=$(jq -r '.evidence.details.oom_killed[0].memory_limit' "$SCRIPT_OUTPUT_FILE")
+  [[ "$oom" == "128Mi" ]] || { echo "expected memory_limit=128Mi, got $oom"; return 1; }
+}
+
+@test "schema: resource_availability emits valid critical evidence with insufficient_cpu flag" {
+  reset_output
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items": [{
+    "metadata": {"name": "unsched"},
+    "status": {"phase":"Pending","conditions":[{"type":"PodScheduled","status":"False","reason":"Unschedulable","message":"0/3 nodes available: insufficient cpu"}]}
+  }]
+}
+EOF
+  source "$BATS_TEST_DIRNAME/../scope/resource_availability" || true
+  assert_evidence_schema "scope/resource_availability (failed)"
+
+  cpu=$(jq -r '.evidence.details.cluster_insufficient_cpu' "$SCRIPT_OUTPUT_FILE")
+  [[ "$cpu" == "true" ]] || { echo "expected insufficient_cpu=true, got $cpu"; return 1; }
+}
+
+@test "schema: ingress_class_validation emits valid critical evidence on missing class" {
+  reset_output
+  cat > "$INGRESSES_FILE" << 'EOF'
+{
+  "items":[{"metadata":{"name":"my-ing"},"spec":{"ingressClassName":"missing-class"}}]
+}
+EOF
+  echo '{"items":[]}' > "$INGRESSCLASSES_FILE"
+  source "$BATS_TEST_DIRNAME/../networking/ingress_class_validation" || true
+  assert_evidence_schema "networking/ingress_class_validation (failed)"
+
+  affected=$(jq -c '.evidence.affected' "$SCRIPT_OUTPUT_FILE")
+  [[ "$affected" == '["my-ing"]' ]] || return 1
+}
+

--- a/k8s/diagnose/tests/logs/application_log_evidence.bats
+++ b/k8s/diagnose/tests/logs/application_log_evidence.bats
@@ -1,0 +1,280 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Unit tests for diagnose/logs/application_log_evidence
+# =============================================================================
+
+setup() {
+  export PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../../../.." && pwd)"
+  source "$PROJECT_ROOT/testing/assertions.sh"
+  source "$BATS_TEST_DIRNAME/../../utils/diagnose_utils"
+
+  export NAMESPACE="test-ns"
+  export LABEL_SELECTOR="app=test"
+  export NP_OUTPUT_DIR="$(mktemp -d)"
+  export SCRIPT_OUTPUT_FILE="$(mktemp)"
+  export SCRIPT_LOG_FILE="$(mktemp)"
+  echo '{"status":"pending","evidence":{},"logs":[]}' > "$SCRIPT_OUTPUT_FILE"
+
+  export PODS_FILE="$(mktemp)"
+  export DATA_DIR="$(mktemp -d)"
+  export POD_LOGS_DIR="$DATA_DIR/pod_logs"
+  export PROBLEMATIC_PODS_FILE="$DATA_DIR/problematic_pods.txt"
+  mkdir -p "$POD_LOGS_DIR"
+  export EVIDENCE_LOG_TAIL_LINES=50
+}
+
+teardown() {
+  rm -rf "$NP_OUTPUT_DIR" "$DATA_DIR"
+  rm -f "$SCRIPT_OUTPUT_FILE" "$SCRIPT_LOG_FILE" "$PODS_FILE"
+}
+
+# Helper: extract a field from the evidence JSON stored in SCRIPT_OUTPUT_FILE.
+evidence() {
+  jq -r "$1" "$SCRIPT_OUTPUT_FILE"
+}
+
+# =============================================================================
+# Snapshot-unavailable path (no PROBLEMATIC_PODS_FILE)
+# =============================================================================
+@test "logs/application_log_evidence: skipped when PROBLEMATIC_PODS_FILE missing" {
+  rm -f "$PROBLEMATIC_PODS_FILE"
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.status')" = "skipped" ]
+  [ "$(evidence '.evidence.severity')" = "info" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
+}
+
+# =============================================================================
+# No problematic pods (file exists but empty)
+# =============================================================================
+@test "logs/application_log_evidence: success with empty result when no problematic pods" {
+  : > "$PROBLEMATIC_PODS_FILE"
+  echo '{"items":[]}' > "$PODS_FILE"
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.status')" = "success" ]
+  [ "$(evidence '.evidence.severity')" = "info" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
+  [ "$(evidence '.evidence.details.containers_with_logs')" = "0" ]
+  assert_contains "$(evidence '.evidence.summary')" "No problematic pods"
+}
+
+# =============================================================================
+# One pod with current logs
+# =============================================================================
+@test "logs/application_log_evidence: collects current logs from one container with full context" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{
+  "metadata":{"name":"pod-1"},
+  "spec":{"containers":[{"name":"app"}]},
+  "status":{
+    "phase":"Running",
+    "containerStatuses":[{
+      "name":"app",
+      "state":{"running":{}},
+      "restartCount":0
+    }]
+  }
+}]}
+EOF
+  printf 'line1\nline2\nERROR: boom\n' > "$POD_LOGS_DIR/pod-1.app.log"
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.status')" = "success" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "1" ]
+  [ "$(evidence '.evidence.details.containers_with_logs')" = "1" ]
+  [ "$(evidence '.evidence.details.logs[0].pod')" = "pod-1" ]
+  [ "$(evidence '.evidence.details.logs[0].container')" = "app" ]
+  [ "$(evidence '.evidence.details.logs[0].init_container')" = "false" ]
+  # Context fields from the snapshot
+  [ "$(evidence '.evidence.details.logs[0].pod_phase')" = "Running" ]
+  [ "$(evidence '.evidence.details.logs[0].container_state')" = "running" ]
+  [ "$(evidence '.evidence.details.logs[0].restart_count')" = "0" ]
+  # Log content
+  [ "$(evidence '.evidence.details.logs[0].current_logs | length')" = "3" ]
+  [ "$(evidence '.evidence.details.logs[0].previous_logs | length')" = "0" ]
+  assert_contains "$(evidence '.evidence.details.logs[0].current_logs | join("\n")')" "ERROR: boom"
+  [ "$(evidence '.evidence.affected[0]')" = "pod-1" ]
+}
+
+@test "logs/application_log_evidence: surfaces CrashLoopBackOff context with last exit code meaning" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{
+  "metadata":{"name":"pod-1"},
+  "spec":{"containers":[{"name":"app"}]},
+  "status":{
+    "phase":"Running",
+    "containerStatuses":[{
+      "name":"app",
+      "state":{"waiting":{"reason":"CrashLoopBackOff"}},
+      "lastState":{"terminated":{"exitCode":137,"reason":"OOMKilled"}},
+      "restartCount":5
+    }]
+  }
+}]}
+EOF
+  echo "starting up..." > "$POD_LOGS_DIR/pod-1.app.log"
+  echo "killed by OOM" > "$POD_LOGS_DIR/pod-1.app.previous.log"
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.evidence.details.logs[0].container_state')" = "waiting" ]
+  [ "$(evidence '.evidence.details.logs[0].current_state_reason')" = "CrashLoopBackOff" ]
+  [ "$(evidence '.evidence.details.logs[0].restart_count')" = "5" ]
+  [ "$(evidence '.evidence.details.logs[0].last_termination_reason')" = "OOMKilled" ]
+  [ "$(evidence '.evidence.details.logs[0].last_exit_code')" = "137" ]
+  # Reused exit_code_meaning from diagnose_utils
+  assert_contains "$(evidence '.evidence.details.logs[0].last_exit_code_meaning')" "OOMKilled"
+  # Previous logs hold the OOM evidence
+  assert_contains "$(evidence '.evidence.details.logs[0].previous_logs[0]')" "killed by OOM"
+}
+
+@test "logs/application_log_evidence: surfaces pod_reason from Ready condition when not Ready" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{
+  "metadata":{"name":"pod-1"},
+  "spec":{"containers":[{"name":"app"}]},
+  "status":{
+    "phase":"Pending",
+    "conditions":[
+      {"type":"Ready","status":"False","reason":"ContainersNotReady"}
+    ],
+    "containerStatuses":[{
+      "name":"app",
+      "state":{"waiting":{"reason":"ContainerCreating"}},
+      "restartCount":0
+    }]
+  }
+}]}
+EOF
+  echo "creating" > "$POD_LOGS_DIR/pod-1.app.log"
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.evidence.details.logs[0].pod_phase')" = "Pending" ]
+  [ "$(evidence '.evidence.details.logs[0].pod_reason')" = "ContainersNotReady" ]
+  [ "$(evidence '.evidence.details.logs[0].current_state_reason')" = "ContainerCreating" ]
+}
+
+# =============================================================================
+# Current + previous logs
+# =============================================================================
+@test "logs/application_log_evidence: includes previous logs when available" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"app"}]}}]}
+EOF
+  echo "current run output" > "$POD_LOGS_DIR/pod-1.app.log"
+  echo "previous crash output" > "$POD_LOGS_DIR/pod-1.app.previous.log"
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.evidence.details.logs[0].current_logs | length')" = "1" ]
+  [ "$(evidence '.evidence.details.logs[0].previous_logs | length')" = "1" ]
+  assert_contains "$(evidence '.evidence.details.logs[0].previous_logs[0]')" "previous crash output"
+}
+
+# =============================================================================
+# Init container
+# =============================================================================
+@test "logs/application_log_evidence: flags init container with init_container=true" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"initContainers":[{"name":"migrate"}],"containers":[{"name":"app"}]}}]}
+EOF
+  echo "running migrations" > "$POD_LOGS_DIR/pod-1.migrate.log"
+  echo "app started" > "$POD_LOGS_DIR/pod-1.app.log"
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.evidence.details.containers_with_logs')" = "2" ]
+  # Init container appears with init_container=true
+  local init_entry
+  init_entry=$(jq -r '.evidence.details.logs[] | select(.container == "migrate") | .init_container' "$SCRIPT_OUTPUT_FILE")
+  [ "$init_entry" = "true" ]
+  # Regular container appears with init_container=false
+  local regular_entry
+  regular_entry=$(jq -r '.evidence.details.logs[] | select(.container == "app") | .init_container' "$SCRIPT_OUTPUT_FILE")
+  [ "$regular_entry" = "false" ]
+}
+
+# =============================================================================
+# Pod is problematic but has no logs (image never started)
+# =============================================================================
+@test "logs/application_log_evidence: surfaces 'no logs' when problematic pod produced none" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"app"}]}}]}
+EOF
+  # No log files at all (e.g. ImagePullBackOff → container never ran)
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.status')" = "success" ]
+  [ "$(evidence '.evidence.severity')" = "info" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
+  [ "$(evidence '.evidence.details.problematic_pod_count')" = "1" ]
+  assert_contains "$(evidence '.evidence.summary')" "image may never have started"
+}
+
+# =============================================================================
+# Multiple pods, mixed log availability
+# =============================================================================
+@test "logs/application_log_evidence: aggregates multiple pods and reports affected list" {
+  printf 'pod-a\npod-b\npod-c\n' > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{
+  "items":[
+    {"metadata":{"name":"pod-a"},"spec":{"containers":[{"name":"app"}]}},
+    {"metadata":{"name":"pod-b"},"spec":{"containers":[{"name":"app"}]}},
+    {"metadata":{"name":"pod-c"},"spec":{"containers":[{"name":"app"}]}}
+  ]
+}
+EOF
+  echo "pod-a log line" > "$POD_LOGS_DIR/pod-a.app.log"
+  echo "pod-c log line" > "$POD_LOGS_DIR/pod-c.app.log"
+  # pod-b has no log file (image pull issue) — should still be counted as problematic
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "2" ]
+  [ "$(evidence '.evidence.details.containers_with_logs')" = "2" ]
+  [ "$(evidence '.evidence.details.problematic_pod_count')" = "3" ]
+  # Affected only contains pods that produced logs (pod-a, pod-c), not pod-b
+  local affected
+  affected=$(evidence '.evidence.affected | sort | join(",")')
+  [ "$affected" = "pod-a,pod-c" ]
+}
+
+# =============================================================================
+# Empty log file (kubectl returned no output but the file exists)
+# =============================================================================
+@test "logs/application_log_evidence: skips containers whose log file is empty" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"app"}]}}]}
+EOF
+  : > "$POD_LOGS_DIR/pod-1.app.log"  # empty file
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.evidence.details.containers_with_logs')" = "0" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
+}

--- a/k8s/diagnose/tests/logs/application_log_evidence.bats
+++ b/k8s/diagnose/tests/logs/application_log_evidence.bats
@@ -43,13 +43,13 @@ evidence() {
   [ "$status" -eq 0 ]
   [ "$(evidence '.status')" = "skipped" ]
   [ "$(evidence '.evidence.severity')" = "info" ]
-  [ "$(evidence '.evidence.details.pods | length')" = "0" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
 }
 
 # =============================================================================
 # No problematic pods
 # =============================================================================
-@test "logs/application_log_evidence: success with empty payload when no problematic pods" {
+@test "logs/application_log_evidence: success with zero counters when no problematic pods" {
   : > "$PROBLEMATIC_PODS_FILE"
   echo '{"items":[]}' > "$PODS_FILE"
 
@@ -57,14 +57,15 @@ evidence() {
 
   [ "$status" -eq 0 ]
   [ "$(evidence '.status')" = "success" ]
-  [ "$(evidence '.evidence.details.pods | length')" = "0" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
+  [ "$(evidence '.evidence.details.problematic_pod_count')" = "0" ]
   assert_contains "$(evidence '.evidence.summary')" "No problematic pods"
 }
 
 # =============================================================================
-# Focuses on the application container only
+# Focuses on the application container only — sidecars are not echoed
 # =============================================================================
-@test "logs/application_log_evidence: collects only application container logs (ignores sidecars)" {
+@test "logs/application_log_evidence: echoes only application logs (ignores sidecars)" {
   echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
 {"items":[{
@@ -78,28 +79,51 @@ EOF
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.pods | length')" = "1" ]
-  [ "$(evidence '.evidence.details.pods[0].pod')" = "pod-1" ]
-  [ "$(evidence '.evidence.details.pods[0].logs | length')" = "2" ]
-  # Application log must appear, sidecar log must NOT
-  assert_contains "$(evidence '.evidence.details.pods[0].logs | join("\n")')" "missing DATABASE_URL"
-  if [[ "$(evidence '.evidence.details | tostring')" == *"nginx sidecar noise"* ]]; then
-    echo "Sidecar log leaked into evidence"
+  # Header + lines prefixed with "| " appear in stdout (captured by UI logs[])
+  assert_contains "$output" "application log tail from pod-1"
+  assert_contains "$output" "| starting..."
+  assert_contains "$output" "| ERROR: missing DATABASE_URL"
+  # Sidecar must NOT leak
+  if [[ "$output" == *"nginx sidecar noise"* ]]; then
+    echo "Sidecar log leaked into stdout"
     return 1
   fi
-  # No leftover metadata fields from the previous shape (no current/previous split either)
-  for field in pod_phase pod_reason container init_container container_state restart_count last_exit_code current_logs previous_logs; do
-    if [[ "$(evidence ".evidence.details.pods[0].$field")" != "null" ]]; then
-      echo "Unexpected leftover field: $field"
-      return 1
-    fi
-  done
+  # Affected lists the pod, counters reflect success
+  [ "$(evidence '.evidence.affected[0]')" = "pod-1" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "1" ]
+  [ "$(evidence '.evidence.details.problematic_pod_count')" = "1" ]
 }
 
 # =============================================================================
-# Previous + current are merged into a single chronological logs array
+# Evidence has NO log text — only counters
 # =============================================================================
-@test "logs/application_log_evidence: merges previous and current logs in chronological order" {
+@test "logs/application_log_evidence: evidence.details exposes only counters, never log text" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
+EOF
+  echo "secret log line that must not appear in evidence" > "$POD_LOGS_DIR/pod-1.application.log"
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  # details has only the two counters, no pods array, no logs field
+  local keys
+  keys=$(jq -r '.evidence.details | keys | sort | join(",")' "$SCRIPT_OUTPUT_FILE")
+  [ "$keys" = "pods_with_logs,problematic_pod_count" ]
+  # The log text must not appear anywhere in the evidence object
+  if [[ "$(jq -c '.evidence' "$SCRIPT_OUTPUT_FILE")" == *"secret log line"* ]]; then
+    echo "Log text leaked into evidence"
+    return 1
+  fi
+  # But it MUST appear in stdout
+  assert_contains "$output" "| secret log line"
+}
+
+# =============================================================================
+# Previous + current are merged into a single chronological stream on stdout
+# =============================================================================
+@test "logs/application_log_evidence: stdout shows previous logs first, then current" {
   echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
 {"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
@@ -110,18 +134,24 @@ EOF
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  # Single flat logs array, previous first (older) then current (newer)
-  [ "$(evidence '.evidence.details.pods[0].logs | length')" = "2" ]
-  [ "$(evidence '.evidence.details.pods[0].logs[0]')" = "previous crash output" ]
-  [ "$(evidence '.evidence.details.pods[0].logs[1]')" = "current run" ]
+  # Both lines must appear in stdout
+  assert_contains "$output" "| previous crash output"
+  assert_contains "$output" "| current run"
+  # And previous must come before current
+  local prev_line current_line
+  prev_line=$(printf '%s\n' "$output" | grep -n "previous crash output" | head -1 | cut -d: -f1)
+  current_line=$(printf '%s\n' "$output" | grep -n "current run" | head -1 | cut -d: -f1)
+  [ "$prev_line" -lt "$current_line" ] || { echo "Expected previous to print before current"; return 1; }
 }
 
-@test "logs/application_log_evidence: caps logs to the last 50 lines (EVIDENCE_LOG_TAIL_LINES default)" {
+# =============================================================================
+# Caps logs to last 50 lines (EVIDENCE_LOG_TAIL_LINES default)
+# =============================================================================
+@test "logs/application_log_evidence: caps echoed logs to the last 50 lines" {
   echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
 {"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
 EOF
-  # 30 previous + 30 current = 60 lines combined; only last 50 must survive
   for i in $(seq 1 30); do echo "prev-$i" >> "$POD_LOGS_DIR/pod-1.application.previous.log"; done
   for i in $(seq 1 30); do echo "curr-$i" >> "$POD_LOGS_DIR/pod-1.application.log"; done
 
@@ -130,10 +160,19 @@ EOF
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.pods[0].logs | length')" = "50" ]
-  # Should keep the latest 50 — the first 10 previous lines drop off
-  [ "$(evidence '.evidence.details.pods[0].logs[0]')" = "prev-11" ]
-  [ "$(evidence '.evidence.details.pods[0].logs[-1]')" = "curr-30" ]
+  # 60 input lines, capped at 50 → the first 10 previous lines must drop off
+  if [[ "$output" == *"| prev-1"$'\n'* || "$output" == *"| prev-1 "* ]]; then
+    : # 'prev-1' is a prefix of 'prev-10', need stricter match
+  fi
+  # Stricter check: 'prev-10' should not appear because only prev-11..30 + curr-1..30 fit
+  if printf '%s\n' "$output" | grep -qE '\| prev-10$'; then
+    echo "Expected prev-10 to be dropped (out of tail-50 window)"
+    return 1
+  fi
+  # But prev-11 should be there (first survivor)
+  printf '%s\n' "$output" | grep -qE '\| prev-11$' || { echo "Expected prev-11 to survive"; return 1; }
+  # And the latest current line is the last visible
+  printf '%s\n' "$output" | grep -qE '\| curr-30$' || { echo "Expected curr-30 to survive"; return 1; }
 }
 
 # =============================================================================
@@ -149,7 +188,8 @@ EOF
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.pods | length')" = "0" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
+  [ "$(evidence '.evidence.details.problematic_pod_count')" = "1" ]
   assert_contains "$(evidence '.evidence.summary')" "No application logs available"
 }
 
@@ -161,56 +201,42 @@ EOF
   cat > "$PODS_FILE" <<'EOF'
 {"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
 EOF
-  # No log files (e.g. ImagePullBackOff)
+  # No log files
 
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.pods | length')" = "0" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
   assert_contains "$(evidence '.evidence.summary')" "image may never have started"
 }
 
 # =============================================================================
 # Multiple pods aggregated
 # =============================================================================
-@test "logs/application_log_evidence: aggregates application logs across multiple pods" {
+@test "logs/application_log_evidence: aggregates affected across multiple pods" {
   printf 'pod-a\npod-b\npod-c\n' > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
 {
   "items":[
-    {"metadata":{"name":"pod-a"},"spec":{"containers":[{"name":"http"},{"name":"application"}]}},
-    {"metadata":{"name":"pod-b"},"spec":{"containers":[{"name":"http"},{"name":"application"}]}},
-    {"metadata":{"name":"pod-c"},"spec":{"containers":[{"name":"http"},{"name":"application"}]}}
+    {"metadata":{"name":"pod-a"},"spec":{"containers":[{"name":"application"}]}},
+    {"metadata":{"name":"pod-b"},"spec":{"containers":[{"name":"application"}]}},
+    {"metadata":{"name":"pod-c"},"spec":{"containers":[{"name":"application"}]}}
   ]
 }
 EOF
   echo "log of A" > "$POD_LOGS_DIR/pod-a.application.log"
   echo "log of C" > "$POD_LOGS_DIR/pod-c.application.log"
-  # pod-b has no application log file → dropped silently
+  # pod-b has no log file
 
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.pods | length')" = "2" ]
+  [ "$(evidence '.evidence.details.pods_with_logs')" = "2" ]
+  [ "$(evidence '.evidence.details.problematic_pod_count')" = "3" ]
   local affected
   affected=$(evidence '.evidence.affected | sort | join(",")')
   [ "$affected" = "pod-a,pod-c" ]
-}
-
-# =============================================================================
-# Schema sanity: only the documented top-level fields are present
-# =============================================================================
-@test "logs/application_log_evidence: pod entry exposes exactly {pod, logs}" {
-  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
-  cat > "$PODS_FILE" <<'EOF'
-{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
-EOF
-  echo "a line" > "$POD_LOGS_DIR/pod-1.application.log"
-
-  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
-
-  [ "$status" -eq 0 ]
-  local keys
-  keys=$(jq -r '.evidence.details.pods[0] | keys | sort | join(",")' "$SCRIPT_OUTPUT_FILE")
-  [ "$keys" = "logs,pod" ]
+  # Both visible in stdout, pod-b absent
+  assert_contains "$output" "| log of A"
+  assert_contains "$output" "| log of C"
 }

--- a/k8s/diagnose/tests/logs/application_log_evidence.bats
+++ b/k8s/diagnose/tests/logs/application_log_evidence.bats
@@ -28,13 +28,12 @@ teardown() {
   rm -f "$SCRIPT_OUTPUT_FILE" "$SCRIPT_LOG_FILE" "$PODS_FILE"
 }
 
-# Helper: extract a field from the evidence JSON stored in SCRIPT_OUTPUT_FILE.
 evidence() {
   jq -r "$1" "$SCRIPT_OUTPUT_FILE"
 }
 
 # =============================================================================
-# Snapshot-unavailable path (no PROBLEMATIC_PODS_FILE)
+# Snapshot-unavailable path
 # =============================================================================
 @test "logs/application_log_evidence: skipped when PROBLEMATIC_PODS_FILE missing" {
   rm -f "$PROBLEMATIC_PODS_FILE"
@@ -44,13 +43,13 @@ evidence() {
   [ "$status" -eq 0 ]
   [ "$(evidence '.status')" = "skipped" ]
   [ "$(evidence '.evidence.severity')" = "info" ]
-  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
+  [ "$(evidence '.evidence.details.pods | length')" = "0" ]
 }
 
 # =============================================================================
-# No problematic pods (file exists but empty)
+# No problematic pods
 # =============================================================================
-@test "logs/application_log_evidence: success with empty result when no problematic pods" {
+@test "logs/application_log_evidence: success with empty payload when no problematic pods" {
   : > "$PROBLEMATIC_PODS_FILE"
   echo '{"items":[]}' > "$PODS_FILE"
 
@@ -58,223 +57,160 @@ evidence() {
 
   [ "$status" -eq 0 ]
   [ "$(evidence '.status')" = "success" ]
-  [ "$(evidence '.evidence.severity')" = "info" ]
-  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
-  [ "$(evidence '.evidence.details.containers_with_logs')" = "0" ]
+  [ "$(evidence '.evidence.details.pods | length')" = "0" ]
   assert_contains "$(evidence '.evidence.summary')" "No problematic pods"
 }
 
 # =============================================================================
-# One pod with current logs
+# Focuses on the application container only
 # =============================================================================
-@test "logs/application_log_evidence: collects current logs from one container with full context" {
+@test "logs/application_log_evidence: collects only application container logs (ignores sidecars)" {
   echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
 {"items":[{
   "metadata":{"name":"pod-1"},
-  "spec":{"containers":[{"name":"app"}]},
-  "status":{
-    "phase":"Running",
-    "containerStatuses":[{
-      "name":"app",
-      "state":{"running":{}},
-      "restartCount":0
-    }]
-  }
+  "spec":{"containers":[{"name":"http"},{"name":"application"}]}
 }]}
 EOF
-  printf 'line1\nline2\nERROR: boom\n' > "$POD_LOGS_DIR/pod-1.app.log"
+  echo "nginx sidecar noise" > "$POD_LOGS_DIR/pod-1.http.log"
+  printf 'starting...\nERROR: missing DATABASE_URL\n' > "$POD_LOGS_DIR/pod-1.application.log"
 
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.status')" = "success" ]
-  [ "$(evidence '.evidence.details.pods_with_logs')" = "1" ]
-  [ "$(evidence '.evidence.details.containers_with_logs')" = "1" ]
-  [ "$(evidence '.evidence.details.logs[0].pod')" = "pod-1" ]
-  [ "$(evidence '.evidence.details.logs[0].container')" = "app" ]
-  [ "$(evidence '.evidence.details.logs[0].init_container')" = "false" ]
-  # Context fields from the snapshot
-  [ "$(evidence '.evidence.details.logs[0].pod_phase')" = "Running" ]
-  [ "$(evidence '.evidence.details.logs[0].container_state')" = "running" ]
-  [ "$(evidence '.evidence.details.logs[0].restart_count')" = "0" ]
-  # Log content
-  [ "$(evidence '.evidence.details.logs[0].current_logs | length')" = "3" ]
-  [ "$(evidence '.evidence.details.logs[0].previous_logs | length')" = "0" ]
-  assert_contains "$(evidence '.evidence.details.logs[0].current_logs | join("\n")')" "ERROR: boom"
-  [ "$(evidence '.evidence.affected[0]')" = "pod-1" ]
-}
-
-@test "logs/application_log_evidence: surfaces CrashLoopBackOff context with last exit code meaning" {
-  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
-  cat > "$PODS_FILE" <<'EOF'
-{"items":[{
-  "metadata":{"name":"pod-1"},
-  "spec":{"containers":[{"name":"app"}]},
-  "status":{
-    "phase":"Running",
-    "containerStatuses":[{
-      "name":"app",
-      "state":{"waiting":{"reason":"CrashLoopBackOff"}},
-      "lastState":{"terminated":{"exitCode":137,"reason":"OOMKilled"}},
-      "restartCount":5
-    }]
-  }
-}]}
-EOF
-  echo "starting up..." > "$POD_LOGS_DIR/pod-1.app.log"
-  echo "killed by OOM" > "$POD_LOGS_DIR/pod-1.app.previous.log"
-
-  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
-
-  [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.logs[0].container_state')" = "waiting" ]
-  [ "$(evidence '.evidence.details.logs[0].current_state_reason')" = "CrashLoopBackOff" ]
-  [ "$(evidence '.evidence.details.logs[0].restart_count')" = "5" ]
-  [ "$(evidence '.evidence.details.logs[0].last_termination_reason')" = "OOMKilled" ]
-  [ "$(evidence '.evidence.details.logs[0].last_exit_code')" = "137" ]
-  # Reused exit_code_meaning from diagnose_utils
-  assert_contains "$(evidence '.evidence.details.logs[0].last_exit_code_meaning')" "OOMKilled"
-  # Previous logs hold the OOM evidence
-  assert_contains "$(evidence '.evidence.details.logs[0].previous_logs[0]')" "killed by OOM"
-}
-
-@test "logs/application_log_evidence: surfaces pod_reason from Ready condition when not Ready" {
-  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
-  cat > "$PODS_FILE" <<'EOF'
-{"items":[{
-  "metadata":{"name":"pod-1"},
-  "spec":{"containers":[{"name":"app"}]},
-  "status":{
-    "phase":"Pending",
-    "conditions":[
-      {"type":"Ready","status":"False","reason":"ContainersNotReady"}
-    ],
-    "containerStatuses":[{
-      "name":"app",
-      "state":{"waiting":{"reason":"ContainerCreating"}},
-      "restartCount":0
-    }]
-  }
-}]}
-EOF
-  echo "creating" > "$POD_LOGS_DIR/pod-1.app.log"
-
-  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
-
-  [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.logs[0].pod_phase')" = "Pending" ]
-  [ "$(evidence '.evidence.details.logs[0].pod_reason')" = "ContainersNotReady" ]
-  [ "$(evidence '.evidence.details.logs[0].current_state_reason')" = "ContainerCreating" ]
+  [ "$(evidence '.evidence.details.pods | length')" = "1" ]
+  [ "$(evidence '.evidence.details.pods[0].pod')" = "pod-1" ]
+  [ "$(evidence '.evidence.details.pods[0].logs | length')" = "2" ]
+  # Application log must appear, sidecar log must NOT
+  assert_contains "$(evidence '.evidence.details.pods[0].logs | join("\n")')" "missing DATABASE_URL"
+  if [[ "$(evidence '.evidence.details | tostring')" == *"nginx sidecar noise"* ]]; then
+    echo "Sidecar log leaked into evidence"
+    return 1
+  fi
+  # No leftover metadata fields from the previous shape (no current/previous split either)
+  for field in pod_phase pod_reason container init_container container_state restart_count last_exit_code current_logs previous_logs; do
+    if [[ "$(evidence ".evidence.details.pods[0].$field")" != "null" ]]; then
+      echo "Unexpected leftover field: $field"
+      return 1
+    fi
+  done
 }
 
 # =============================================================================
-# Current + previous logs
+# Previous + current are merged into a single chronological logs array
 # =============================================================================
-@test "logs/application_log_evidence: includes previous logs when available" {
+@test "logs/application_log_evidence: merges previous and current logs in chronological order" {
   echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
-{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"app"}]}}]}
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
 EOF
-  echo "current run output" > "$POD_LOGS_DIR/pod-1.app.log"
-  echo "previous crash output" > "$POD_LOGS_DIR/pod-1.app.previous.log"
+  echo "current run" > "$POD_LOGS_DIR/pod-1.application.log"
+  echo "previous crash output" > "$POD_LOGS_DIR/pod-1.application.previous.log"
 
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.logs[0].current_logs | length')" = "1" ]
-  [ "$(evidence '.evidence.details.logs[0].previous_logs | length')" = "1" ]
-  assert_contains "$(evidence '.evidence.details.logs[0].previous_logs[0]')" "previous crash output"
+  # Single flat logs array, previous first (older) then current (newer)
+  [ "$(evidence '.evidence.details.pods[0].logs | length')" = "2" ]
+  [ "$(evidence '.evidence.details.pods[0].logs[0]')" = "previous crash output" ]
+  [ "$(evidence '.evidence.details.pods[0].logs[1]')" = "current run" ]
+}
+
+@test "logs/application_log_evidence: caps logs to the last 50 lines (EVIDENCE_LOG_TAIL_LINES default)" {
+  echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
+  cat > "$PODS_FILE" <<'EOF'
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
+EOF
+  # 30 previous + 30 current = 60 lines combined; only last 50 must survive
+  for i in $(seq 1 30); do echo "prev-$i" >> "$POD_LOGS_DIR/pod-1.application.previous.log"; done
+  for i in $(seq 1 30); do echo "curr-$i" >> "$POD_LOGS_DIR/pod-1.application.log"; done
+
+  export EVIDENCE_LOG_TAIL_LINES=50
+
+  run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
+
+  [ "$status" -eq 0 ]
+  [ "$(evidence '.evidence.details.pods[0].logs | length')" = "50" ]
+  # Should keep the latest 50 — the first 10 previous lines drop off
+  [ "$(evidence '.evidence.details.pods[0].logs[0]')" = "prev-11" ]
+  [ "$(evidence '.evidence.details.pods[0].logs[-1]')" = "curr-30" ]
 }
 
 # =============================================================================
-# Init container
+# Pod without application container is skipped
 # =============================================================================
-@test "logs/application_log_evidence: flags init container with init_container=true" {
+@test "logs/application_log_evidence: skips pods that have no application container" {
   echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
-{"items":[{"metadata":{"name":"pod-1"},"spec":{"initContainers":[{"name":"migrate"}],"containers":[{"name":"app"}]}}]}
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"sidecar-only"}]}}]}
 EOF
-  echo "running migrations" > "$POD_LOGS_DIR/pod-1.migrate.log"
-  echo "app started" > "$POD_LOGS_DIR/pod-1.app.log"
+  echo "irrelevant" > "$POD_LOGS_DIR/pod-1.sidecar-only.log"
 
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.containers_with_logs')" = "2" ]
-  # Init container appears with init_container=true
-  local init_entry
-  init_entry=$(jq -r '.evidence.details.logs[] | select(.container == "migrate") | .init_container' "$SCRIPT_OUTPUT_FILE")
-  [ "$init_entry" = "true" ]
-  # Regular container appears with init_container=false
-  local regular_entry
-  regular_entry=$(jq -r '.evidence.details.logs[] | select(.container == "app") | .init_container' "$SCRIPT_OUTPUT_FILE")
-  [ "$regular_entry" = "false" ]
+  [ "$(evidence '.evidence.details.pods | length')" = "0" ]
+  assert_contains "$(evidence '.evidence.summary')" "No application logs available"
 }
 
 # =============================================================================
-# Pod is problematic but has no logs (image never started)
+# Pod has application container but it produced no logs
 # =============================================================================
-@test "logs/application_log_evidence: surfaces 'no logs' when problematic pod produced none" {
+@test "logs/application_log_evidence: drops pod whose application container has no logs" {
   echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
-{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"app"}]}}]}
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
 EOF
-  # No log files at all (e.g. ImagePullBackOff → container never ran)
+  # No log files (e.g. ImagePullBackOff)
 
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.status')" = "success" ]
-  [ "$(evidence '.evidence.severity')" = "info" ]
-  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
-  [ "$(evidence '.evidence.details.problematic_pod_count')" = "1" ]
+  [ "$(evidence '.evidence.details.pods | length')" = "0" ]
   assert_contains "$(evidence '.evidence.summary')" "image may never have started"
 }
 
 # =============================================================================
-# Multiple pods, mixed log availability
+# Multiple pods aggregated
 # =============================================================================
-@test "logs/application_log_evidence: aggregates multiple pods and reports affected list" {
+@test "logs/application_log_evidence: aggregates application logs across multiple pods" {
   printf 'pod-a\npod-b\npod-c\n' > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
 {
   "items":[
-    {"metadata":{"name":"pod-a"},"spec":{"containers":[{"name":"app"}]}},
-    {"metadata":{"name":"pod-b"},"spec":{"containers":[{"name":"app"}]}},
-    {"metadata":{"name":"pod-c"},"spec":{"containers":[{"name":"app"}]}}
+    {"metadata":{"name":"pod-a"},"spec":{"containers":[{"name":"http"},{"name":"application"}]}},
+    {"metadata":{"name":"pod-b"},"spec":{"containers":[{"name":"http"},{"name":"application"}]}},
+    {"metadata":{"name":"pod-c"},"spec":{"containers":[{"name":"http"},{"name":"application"}]}}
   ]
 }
 EOF
-  echo "pod-a log line" > "$POD_LOGS_DIR/pod-a.app.log"
-  echo "pod-c log line" > "$POD_LOGS_DIR/pod-c.app.log"
-  # pod-b has no log file (image pull issue) — should still be counted as problematic
+  echo "log of A" > "$POD_LOGS_DIR/pod-a.application.log"
+  echo "log of C" > "$POD_LOGS_DIR/pod-c.application.log"
+  # pod-b has no application log file → dropped silently
 
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.pods_with_logs')" = "2" ]
-  [ "$(evidence '.evidence.details.containers_with_logs')" = "2" ]
-  [ "$(evidence '.evidence.details.problematic_pod_count')" = "3" ]
-  # Affected only contains pods that produced logs (pod-a, pod-c), not pod-b
+  [ "$(evidence '.evidence.details.pods | length')" = "2" ]
   local affected
   affected=$(evidence '.evidence.affected | sort | join(",")')
   [ "$affected" = "pod-a,pod-c" ]
 }
 
 # =============================================================================
-# Empty log file (kubectl returned no output but the file exists)
+# Schema sanity: only the documented top-level fields are present
 # =============================================================================
-@test "logs/application_log_evidence: skips containers whose log file is empty" {
+@test "logs/application_log_evidence: pod entry exposes exactly {pod, logs}" {
   echo "pod-1" > "$PROBLEMATIC_PODS_FILE"
   cat > "$PODS_FILE" <<'EOF'
-{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"app"}]}}]}
+{"items":[{"metadata":{"name":"pod-1"},"spec":{"containers":[{"name":"application"}]}}]}
 EOF
-  : > "$POD_LOGS_DIR/pod-1.app.log"  # empty file
+  echo "a line" > "$POD_LOGS_DIR/pod-1.application.log"
 
   run bash -c "source '$BATS_TEST_DIRNAME/../../utils/diagnose_utils' && source '$BATS_TEST_DIRNAME/../../logs/application_log_evidence'"
 
   [ "$status" -eq 0 ]
-  [ "$(evidence '.evidence.details.containers_with_logs')" = "0" ]
-  [ "$(evidence '.evidence.details.pods_with_logs')" = "0" ]
+  local keys
+  keys=$(jq -r '.evidence.details.pods[0] | keys | sort | join(",")' "$SCRIPT_OUTPUT_FILE")
+  [ "$keys" = "logs,pod" ]
 }

--- a/k8s/diagnose/tests/scope/container_crash_detection.bats
+++ b/k8s/diagnose/tests/scope/container_crash_detection.bats
@@ -268,3 +268,103 @@ EOF
   result=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$result" "failed"
 }
+
+# =============================================================================
+# Evidence Schema Tests
+# =============================================================================
+@test "scope/container_crash_detection: success evidence follows schema" {
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items": [{
+    "metadata": {"name": "healthy-pod"},
+    "status": {"containerStatuses": [{"name": "app", "ready": true, "restartCount": 0, "state": {"running": {}}}]}
+  }]
+}
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../scope/container_crash_detection"
+
+  severity=$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$severity" "info"
+
+  summary=$(jq -r '.evidence.summary' "$SCRIPT_OUTPUT_FILE")
+  assert_contains "$summary" "running without crashes"
+
+  affected=$(jq -c '.evidence.affected' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$affected" "[]"
+
+  pods_checked=$(jq -r '.evidence.details.pods_checked' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$pods_checked" "1"
+}
+
+@test "scope/container_crash_detection: failed evidence includes affected pods and crash details" {
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items": [
+    {
+      "metadata": {"name": "crash-1"},
+      "status": {"containerStatuses": [{"name": "app", "restartCount": 5, "state": {"waiting": {"reason": "CrashLoopBackOff"}}, "lastState": {"terminated": {"exitCode": 137, "reason": "OOMKilled"}}}]}
+    },
+    {
+      "metadata": {"name": "healthy"},
+      "status": {"containerStatuses": [{"name": "app", "ready": true, "restartCount": 0, "state": {"running": {}}}]}
+    }
+  ]
+}
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../scope/container_crash_detection"
+
+  severity=$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$severity" "critical"
+
+  affected=$(jq -c '.evidence.affected' "$SCRIPT_OUTPUT_FILE")
+  assert_contains "$affected" "crash-1"
+
+  oom_count=$(jq -r '.evidence.details.counts.oom_killed' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$oom_count" "1"
+
+  crash_pod=$(jq -r '.evidence.details.crash_loop_back_off[0].pod' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$crash_pod" "crash-1"
+
+  exit_code=$(jq -r '.evidence.details.crash_loop_back_off[0].exit_code' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$exit_code" "137"
+
+  exit_meaning=$(jq -r '.evidence.details.crash_loop_back_off[0].exit_code_meaning' "$SCRIPT_OUTPUT_FILE")
+  assert_contains "$exit_meaning" "OOMKilled"
+
+  # Suggested actions should not be empty
+  actions_count=$(jq -r '.evidence.suggested_actions | length' "$SCRIPT_OUTPUT_FILE")
+  [ "$actions_count" -gt 0 ]
+}
+
+@test "scope/container_crash_detection: summary highlights OOM count when present" {
+  cat > "$PODS_FILE" << 'EOF'
+{
+  "items": [{
+    "metadata": {"name": "oom-pod"},
+    "status": {"containerStatuses": [{"name": "app", "restartCount": 1, "state": {"waiting": {"reason": "CrashLoopBackOff"}}, "lastState": {"terminated": {"exitCode": 137, "reason": "OOMKilled"}}}]}
+  }]
+}
+EOF
+
+  source "$BATS_TEST_DIRNAME/../../scope/container_crash_detection"
+
+  summary=$(jq -r '.evidence.summary' "$SCRIPT_OUTPUT_FILE")
+  assert_contains "$summary" "OOMKilled"
+}
+
+@test "scope/container_crash_detection: skipped evidence follows schema with info severity" {
+  echo '{"items":[]}' > "$PODS_FILE"
+
+  source "$BATS_TEST_DIRNAME/../../scope/container_crash_detection"
+
+  status=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$status" "skipped"
+
+  severity=$(jq -r '.evidence.severity' "$SCRIPT_OUTPUT_FILE")
+  assert_equal "$severity" "info"
+
+  summary=$(jq -r '.evidence.summary' "$SCRIPT_OUTPUT_FILE")
+  assert_contains "$summary" "skipped"
+}

--- a/k8s/diagnose/tests/scope/container_port_health.bats
+++ b/k8s/diagnose/tests/scope/container_port_health.bats
@@ -187,7 +187,7 @@ EOF
   result=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$result" "failed"
 
-  tested=$(jq -r '.evidence.tested' "$SCRIPT_OUTPUT_FILE")
+  tested=$(jq -r '.evidence.details.containers_tested' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$tested" "1"
 }
 
@@ -429,7 +429,7 @@ EOF
   result=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$result" "skipped"
 
-  skipped=$(jq -r '.evidence.skipped' "$SCRIPT_OUTPUT_FILE")
+  skipped=$(jq -r '.evidence.details.containers_skipped' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$skipped" "1"
 }
 
@@ -498,7 +498,7 @@ EOF
   result=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$result" "success"
 
-  tested=$(jq -r '.evidence.tested' "$SCRIPT_OUTPUT_FILE")
+  tested=$(jq -r '.evidence.details.containers_tested' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$tested" "1"
 
   unset -f nc timeout

--- a/k8s/diagnose/tests/scope/health_probe_endpoints.bats
+++ b/k8s/diagnose/tests/scope/health_probe_endpoints.bats
@@ -562,7 +562,7 @@ EOF
   result=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$result" "skipped"
 
-  skipped=$(jq -r '.evidence.skipped' "$SCRIPT_OUTPUT_FILE")
+  skipped=$(jq -r '.evidence.details.containers_skipped' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$skipped" "1"
 }
 
@@ -675,7 +675,7 @@ EOF
   result=$(jq -r '.status' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$result" "success"
 
-  tested=$(jq -r '.evidence.tested' "$SCRIPT_OUTPUT_FILE")
+  tested=$(jq -r '.evidence.details.containers_tested' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$tested" "1"
 }
 

--- a/k8s/diagnose/tests/scope/pod_readiness.bats
+++ b/k8s/diagnose/tests/scope/pod_readiness.bats
@@ -223,8 +223,8 @@ EOF
 
   source "$BATS_TEST_DIRNAME/../../scope/pod_readiness"
 
-  ready=$(jq -r '.evidence.ready' "$SCRIPT_OUTPUT_FILE")
-  total=$(jq -r '.evidence.total' "$SCRIPT_OUTPUT_FILE")
+  ready=$(jq -r '.evidence.details.ready' "$SCRIPT_OUTPUT_FILE")
+  total=$(jq -r '.evidence.details.total' "$SCRIPT_OUTPUT_FILE")
   assert_equal "$ready" "1"
   assert_equal "$total" "1"
 }

--- a/k8s/diagnose/utils/diagnose_utils
+++ b/k8s/diagnose/utils/diagnose_utils
@@ -117,7 +117,63 @@ read_log_tail() {
         return 0
     fi
 
-    tail -n "$lines" "$log_file" | jq -R -s 'split("\n") | map(select(length > 0))'
+    tail -n "$lines" "$log_file" | lines_to_json_array
+}
+
+# Convert newline-delimited stdin into a JSON array of non-empty strings.
+# Used by read_log_tail and update_check_result to share one canonical
+# tail-text-to-JSON pipeline.
+lines_to_json_array() {
+    jq -R -s 'split("\n") | map(select(length > 0))'
+}
+
+# Append a JSON object to a bash indexed array (passed by name). Avoids the
+# O(N²) jq round-trip of `arr=$(echo "$arr" | jq --argjson f "$x" '. + [$f]')`.
+# Convert with `facts_to_json_array <name>` once at end of accumulation.
+# Uses eval so it works on bash 3.2 (macOS dev) — declare -n requires 4.3+.
+add_fact() {
+    local arr_name="$1"
+    local value="$2"
+    eval "${arr_name}+=(\"\$value\")"
+}
+
+# Convert a bash indexed array of compact JSON strings into a single JSON
+# array. Empty arrays correctly become "[]".
+facts_to_json_array() {
+    local arr_name="$1"
+    local count
+    eval "count=\${#${arr_name}[@]}"
+    if [[ "$count" -eq 0 ]]; then
+        echo "[]"
+    else
+        eval "printf '%s\n' \"\${${arr_name}[@]}\"" | jq -s '.'
+    fi
+}
+
+# Mark a resource as affected by an issue. Stores names in a bash variable
+# (passed by name) as a space-separated set, deduplicating on add. Replaces
+# the per-call jq dedup that was duplicated in every check.
+mark_affected() {
+    local set_name="$1"
+    local value="$2"
+    local current
+    eval "current=\"\${$set_name}\""
+    case " $current " in
+        *" $value "*) ;;
+        *) eval "$set_name=\"\${current:+\$current }\$value\"" ;;
+    esac
+}
+
+# Convert a space-separated set (built by mark_affected) into a JSON array.
+set_to_json_array() {
+    local set_name="$1"
+    local values
+    eval "values=\"\${$set_name}\""
+    if [[ -z "$values" ]]; then
+        echo "[]"
+    else
+        printf '%s\n' $values | jq -R . | jq -s .
+    fi
 }
 
 print_success() {
@@ -216,11 +272,10 @@ update_check_result() {
         return 1
     fi
 
-    # Check if log file exists and read it into an array
+    # Read script log tail (last 20 non-blank lines) into a JSON array
     local log_array="[]"
     if [[ -n "$SCRIPT_LOG_FILE" && -f "$SCRIPT_LOG_FILE" ]]; then
-        # Read log file, remove empty lines, take last 20 lines, and convert to JSON array
-        log_array=$(grep -v '^[[:space:]]*$' "$SCRIPT_LOG_FILE" | tail -n 20 | jq -R -s 'split("\n") | map(select(length > 0))')
+        log_array=$(grep -v '^[[:space:]]*$' "$SCRIPT_LOG_FILE" | tail -n 20 | lines_to_json_array)
         if [[ $? -ne 0 ]]; then
             echo "Error: Failed to read log file: $SCRIPT_LOG_FILE" >&2
             return 1

--- a/k8s/diagnose/utils/diagnose_utils
+++ b/k8s/diagnose/utils/diagnose_utils
@@ -1,11 +1,83 @@
 #!/bin/bash
 
+# =============================================================================
+# Evidence schema (passed to update_check_result --evidence)
+# =============================================================================
+# All checks must emit evidence following this schema so the backend / AI summarizer
+# can consume results uniformly:
+#
+#   {
+#     "summary":           "string — one-line human-readable summary of findings",
+#     "severity":          "critical" | "warning" | "info",
+#     "affected":          ["resource-name", ...],
+#     "details":           { /* check-specific structured data */ },
+#     "suggested_actions": ["actionable guidance items"]
+#   }
+#
+# severity mapping:
+#   - critical: status=failed with actionable data (e.g. pods OOMKilled)
+#   - warning:  status=warning, or partial issues
+#   - info:     status=success or skipped (no action required)
+#
+# Helper `evidence_json` below builds this schema from primitives.
+# =============================================================================
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m' # No Color
+
+# Build a JSON evidence object following the schema documented above.
+# Usage:
+#   evidence_json <summary> <severity> <affected_json> <details_json> <actions_json>
+# Where:
+#   - summary:        plain string
+#   - severity:       "critical" | "warning" | "info"
+#   - affected_json:  JSON array of resource names, e.g. '["pod-1","pod-2"]'
+#   - details_json:   JSON object, check-specific. Pass '{}' for none.
+#   - actions_json:   JSON array of strings. Pass '[]' for none.
+evidence_json() {
+    local summary="$1"
+    local severity="$2"
+    local affected="$3"
+    local details="$4"
+    local actions="$5"
+
+    # Explicit defaults: bash's ${var:-{}} mis-parses the closing brace, so we
+    # branch instead of using parameter substitution.
+    [[ -z "$affected" ]] && affected="[]"
+    [[ -z "$details"  ]] && details="{}"
+    [[ -z "$actions"  ]] && actions="[]"
+
+    jq -n \
+        --arg summary "$summary" \
+        --arg severity "$severity" \
+        --argjson affected "$affected" \
+        --argjson details "$details" \
+        --argjson actions "$actions" \
+        '{
+            summary: $summary,
+            severity: $severity,
+            affected: $affected,
+            details: $details,
+            suggested_actions: $actions
+        }'
+}
+
+# Translate a Linux container exit code into a human-readable meaning.
+# Returns "Unknown" for codes we don't classify.
+exit_code_meaning() {
+    case "$1" in
+        0)   echo "Clean exit (container finished successfully)" ;;
+        1)   echo "Application error" ;;
+        137) echo "OOMKilled (out of memory)" ;;
+        139) echo "SIGSEGV (segmentation fault)" ;;
+        143) echo "SIGTERM (graceful termination)" ;;
+        *)   echo "Unknown" ;;
+    esac
+}
 
 print_success() {
     echo -e "${GREEN}✓${NC} $1"
@@ -37,7 +109,15 @@ require_resources() {
 
     if [[ -z "$resource_names" ]]; then
         print_warning "No ${resource_type} found with labels $label_selector in namespace $namespace, check was skipped."
-        update_check_result --status "skipped" --evidence "{}"
+        local skip_evidence
+        skip_evidence=$(evidence_json \
+            "No ${resource_type} found, check skipped" \
+            "info" \
+            "[]" \
+            "$(jq -nc --arg rt "$resource_type" --arg ls "$label_selector" --arg ns "$namespace" \
+                '{resource_type: $rt, label_selector: $ls, namespace: $ns}')" \
+            "[]")
+        update_check_result --status "skipped" --evidence "$skip_evidence"
         return 1
     fi
 

--- a/k8s/diagnose/utils/diagnose_utils
+++ b/k8s/diagnose/utils/diagnose_utils
@@ -79,6 +79,47 @@ exit_code_meaning() {
     esac
 }
 
+# Read the tail of a pre-collected pod log into a JSON array of lines (one
+# line per element). Reads from the pod_logs/ snapshot collected by
+# build_context — never makes live kubectl calls.
+#
+# Usage:
+#   read_log_tail <pod> <container> <which> [lines]
+#     which:   "current" or "previous"
+#     lines:   how many lines to take from the tail (default: $EVIDENCE_LOG_TAIL_LINES, fallback 50)
+#
+# Returns "[]" if:
+#   - POD_LOGS_DIR is unset (build_context did not run, or this is a unit test)
+#   - the log file does not exist (most containers do not have a previous log)
+#   - the file is empty (container produced no output yet)
+#
+# Why a snapshot rather than live kubectl: build_context took the snapshot
+# point-in-time at fail-time (diagnose runs before rollback). By the time the
+# AI summarizer reads evidence, the cluster state has likely moved on, so live
+# logs would be misleading or missing.
+read_log_tail() {
+    local pod="$1"
+    local container="$2"
+    local which="$3"
+    local lines="${4:-${EVIDENCE_LOG_TAIL_LINES:-50}}"
+
+    [[ -z "$POD_LOGS_DIR" ]] && { echo "[]"; return 0; }
+
+    local log_file
+    case "$which" in
+        previous) log_file="$POD_LOGS_DIR/${pod}.${container}.previous.log" ;;
+        current)  log_file="$POD_LOGS_DIR/${pod}.${container}.log" ;;
+        *)        echo "[]"; return 0 ;;
+    esac
+
+    if [[ ! -s "$log_file" ]]; then
+        echo "[]"
+        return 0
+    fi
+
+    tail -n "$lines" "$log_file" | jq -R -s 'split("\n") | map(select(length > 0))'
+}
+
 print_success() {
     echo -e "${GREEN}✓${NC} $1"
 }

--- a/k8s/diagnose/utils/diagnose_utils
+++ b/k8s/diagnose/utils/diagnose_utils
@@ -243,7 +243,14 @@ update_check_result() {
     # Usage:
     #   update_check_result "new-status" '{"new":"evidence"}'
     # or:
-    #   update_check_result --status "new-status" --evidence '{"new":"evidence"}'
+    #   update_check_result --status "new-status" --evidence '{"new":"evidence"}' [--log-tail-lines N]
+    #
+    # --log-tail-lines overrides the default 20-line cap on the captured stdout
+    # tail. Checks that publish application output (e.g. logs/application_log_evidence)
+    # need a higher cap to fit the log payload alongside their own diagnostic
+    # prints.
+
+    local log_tail_lines=20
 
     # Argument parsing
     if [[ "$1" == --* ]]; then
@@ -251,6 +258,7 @@ update_check_result() {
             case $1 in
                 --status) status="$2"; shift 2 ;;
                 --evidence) evidence="$2"; shift 2 ;;
+                --log-tail-lines) log_tail_lines="$2"; shift 2 ;;
                 *) echo "Unknown parameter: $1" >&2; return 1 ;;
             esac
         done
@@ -272,10 +280,10 @@ update_check_result() {
         return 1
     fi
 
-    # Read script log tail (last 20 non-blank lines) into a JSON array
+    # Read script log tail (non-blank lines, capped at $log_tail_lines) into a JSON array
     local log_array="[]"
     if [[ -n "$SCRIPT_LOG_FILE" && -f "$SCRIPT_LOG_FILE" ]]; then
-        log_array=$(grep -v '^[[:space:]]*$' "$SCRIPT_LOG_FILE" | tail -n 20 | lines_to_json_array)
+        log_array=$(grep -v '^[[:space:]]*$' "$SCRIPT_LOG_FILE" | tail -n "$log_tail_lines" | lines_to_json_array)
         if [[ $? -ne 0 ]]; then
             echo "Error: Failed to read log file: $SCRIPT_LOG_FILE" >&2
             return 1

--- a/k8s/scope/workflows/diagnose.yaml
+++ b/k8s/scope/workflows/diagnose.yaml
@@ -35,3 +35,4 @@ steps:
       - "$SERVICE_PATH/diagnose/service"
       - "$SERVICE_PATH/diagnose/scope"
       - "$SERVICE_PATH/diagnose/networking"
+      - "$SERVICE_PATH/diagnose/logs"


### PR DESCRIPTION
## Summary

Make `k8s/diagnose` evidence consumable by an AI summarizer end-to-end, so that when a deploy fails (and diagnose auto-runs before rollback) the resulting payload is self-contained enough to "cantar la papa" in seconds.

Four substantive layers, plus a simplification pass:

- **Capture** — `build_context` now snapshots `Deployments`, `ReplicaSets`, plus `kubectl describe` and `kubectl logs` (current + `--previous`, init + regular containers) for every problematic pod. All under `data/`, excluded from the backend payload by `notify_results`.
- **Schema** — every one of the 20 checks now emits structured `evidence` following a documented contract: `{summary, severity, affected, details, suggested_actions}`. Helpers in `diagnose_utils` build it. The pre-existing bug in `ingress_tls_configuration` (reading `tls.crt` from `metadata.annotations`) is fixed in passing.
- **Embed** — for the 5 checks where logs explain the failure (`container_crash_detection`, `memory_limits_check`, `health_probe_endpoints`, `container_port_health`, `pod_readiness`), failed-check evidence carries the relevant log slice from the snapshot — `previous_logs` for OOM/CrashLoop, `current_logs` for port/probe issues. Success paths stay log-free to keep the payload light.
- **Surface (new category)** — adds an `Application Logs` category with a single check, `application_log_evidence`, that publishes the user-owned `application` container's log tail (the literal name set in `k8s/deployment/templates/deployment.yaml.tpl`) into the check's `logs[]` view so the UI shows the application output as a first-class artifact. The evidence payload itself carries only counters (`pods_with_logs`, `problematic_pod_count`) and the affected pod list — the log text lives in `logs[]` only, no duplication between `evidence` and `logs[]`. `update_check_result` gained an opt-in `--log-tail-lines` flag (default still 20) so this check can push the cap to 200 without affecting the other 19 checks.
- **Simplify** — hoists `mark_affected` (was duplicated 18 times) and replaces the per-iteration `jq` accumulator pattern (~60 instances, O(N²) + 100s of jq forks per failing scope) with bash arrays + a single `jq -s` at end. Same output, materially less work.

## Example — Application Logs in the new category

When the customer's app crashes with a missing `DATABASE_URL`, the new check surfaces this in the UI under `Application Logs → Application Log Evidence`:

```
─── application log tail from d-326230662-1058908154-9c59cc494-5wzx5 ───
  | 2026-05-21T12:40:55: PM2 log: App [application:0] starting in -cluster mode-
  | ❌ Missing required environment variable(s):
  |    - DATABASE_URL
  |    Set the variable in the scope parameters and redeploy.
  | 2026-05-21T12:40:55: PM2 log: App [application:1] exited with code [1] via signal [SIGINT]
  | ...
✓ Collected application logs from 1 of 1 problematic pod(s)
```

And the evidence payload stays small:

```json
{
  "summary": "Collected application logs from 1 of 1 problematic pod(s)",
  "severity": "info",
  "affected": ["d-326230662-1058908154-9c59cc494-5wzx5"],
  "details": {
    "pods_with_logs": 1,
    "problematic_pod_count": 1
  },
  "suggested_actions": []
}
```

The sidecar `http` (nginx) container's logs are intentionally excluded — those already live in `Health Probe Endpoints` and `Container Port Health` evidence; this check is the focused window on the user code only.

## Test plan

- [x] `bats k8s/diagnose/tests/` — 358 tests, 0 failures.
- [x] End-to-end on a real failing scope with missing `DATABASE_URL`: the new `Application Logs` category appears in the diagnose result, the application log tail is visible in `logs[]` for the check, and `evidence.details` carries only counters (no duplicate log text).
- [ ] Trigger an `OOMKilled` in a test deploy and confirm `container_crash_detection` still embeds `previous_logs` while `Application Log Evidence` shows the same application output in its own category.
- [ ] Trigger an `ImagePullBackOff` and confirm `Application Log Evidence` reports `pods_with_logs: 0` with summary "image may never have started".
- [ ] Confirm the AI summarizer can consume the new schema (or coordinate the schema with whoever wires up the consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
