### PR TITLE
fix: avoid IAM inline policy temp file collision on concurrent scope creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Add support to get AWS credentials via assume role
 - Add support to auto-create ALBs on scope create
+- Fix race condition on IAM role creation when multiple scopes are created concurrently
 
 ## [1.12.0] - 2026-06-08
 - Fix: do not inject file parameter as env vars

--- a/k8s/scope/iam/create_role
+++ b/k8s/scope/iam/create_role
@@ -161,7 +161,7 @@ for ((i=0; i<$POLICIES_COUNT; i++)); do
     POLICY_NAME="inline-policy-$((i+1))"
     log debug "📝 Attaching inline policy: $POLICY_NAME"
 
-    TEMP_POLICY_FILE="/tmp/inline-policy-$i.json"
+    TEMP_POLICY_FILE="$OUTPUT_DIR/inline-policy-$i.json"
     echo "$POLICY_VALUE" > "$TEMP_POLICY_FILE"
 
     aws iam put-role-policy \

--- a/k8s/scope/tests/iam/create_role.bats
+++ b/k8s/scope/tests/iam/create_role.bats
@@ -264,6 +264,58 @@ teardown() {
 }
 
 # =============================================================================
+# Test: Inline policy document is written under OUTPUT_DIR, not /tmp
+# (regression: shared /tmp path collided across concurrent create_role runs)
+# =============================================================================
+@test "create_role: inline policy document is written under OUTPUT_DIR" {
+  export IAM='{
+    "ENABLED": "true",
+    "PREFIX": "test-prefix",
+    "ROLE": {
+      "BOUNDARY_ARN": null,
+      "POLICIES": [
+        {"TYPE": "inline", "VALUE": "{\"Version\":\"2012-10-17\",\"Statement\":[]}"}
+      ]
+    }
+  }'
+
+  aws() {
+    case "$*" in
+      *"eks describe-cluster"*)
+        echo "https://oidc.eks.us-east-1.amazonaws.com/id/ABCDEF1234567890"
+        ;;
+      *"sts get-caller-identity"*)
+        echo "123456789012"
+        ;;
+      *"iam create-role"*)
+        echo '{"Role": {"Arn": "arn:aws:iam::123456789012:role/test-prefix-test-scope-123"}}'
+        ;;
+      *"iam put-role-policy"*)
+        # Emit the args so the test can assert on the --policy-document path
+        echo "PUT_ROLE_POLICY_ARGS: $*"
+        ;;
+      *)
+        return 0
+        ;;
+    esac
+  }
+  export -f aws
+
+  run bash -c 'source "$SCRIPT"'
+
+  assert_equal "$status" "0"
+  assert_contains "$output" "--policy-document file://$OUTPUT_DIR/inline-policy-0.json"
+
+  # Guard against the shared /tmp path regression
+  if echo "$output" | grep -q "file:///tmp/inline-policy"; then
+    uses_tmp="true"
+  else
+    uses_tmp="false"
+  fi
+  assert_false "$uses_tmp" "inline policy document under /tmp"
+}
+
+# =============================================================================
 # Test: Unknown policy type shows warning
 # =============================================================================
 @test "create_role: unknown policy type shows warning message" {


### PR DESCRIPTION
## Summary

`k8s/scope/iam/create_role` wrote inline policy documents to a fixed path `/tmp/inline-policy-$i.json`, keyed only by the policy index. When multiple scopes were created concurrently on the same agent, distinct `create_role` runs overwrote each other's file between the `echo` and the `aws iam put-role-policy` call — sending the wrong policy JSON to IAM.

The fix moves the temp file into `$OUTPUT_DIR`, the per-command sandbox the agent already provides (and which the script already uses for `trust-policy.json`), eliminating the race without PIDs, `mktemp`, or locks.

## Changes
- `k8s/scope/iam/create_role`: `/tmp/inline-policy-$i.json` → `$OUTPUT_DIR/inline-policy-$i.json`
- `k8s/scope/tests/iam/create_role.bats`: new regression test asserting the `--policy-document` path is under `$OUTPUT_DIR` and never `/tmp`
- `CHANGELOG.md`: unreleased entry

## Test plan
- `bats tests/iam/create_role.bats` — all 14 tests pass (new test #10 covers the fix)