### PR TITLE
feat: add nodeSelector support for scheduled task scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support to get AWS credentials via assume role
 - Add support to auto-create ALBs on scope create
 - Fix race condition on IAM role creation when multiple scopes are created concurrently
+- Add nodeSelector support for scheduled task scopes
 
 ## [1.12.0] - 2026-06-08
 - Fix: do not inject file parameter as env vars

--- a/scheduled_task/deployment/templates/deployment.yaml.tpl
+++ b/scheduled_task/deployment/templates/deployment.yaml.tpl
@@ -124,6 +124,11 @@ spec:
           tolerations:
 {{ data.ToYAML $tolerations | indent 10 }}
             {{- end }}
+            {{- $nodeSelector := index $deployment "nodeselector" }}
+            {{- if $nodeSelector }}
+          nodeSelector:
+{{ data.ToYAML $nodeSelector | indent 10 }}
+            {{- end }}
           {{- end }}
           {{- if .pull_secrets.ENABLED }}
           imagePullSecrets:


### PR DESCRIPTION
## Summary
Adds `nodeSelector` support to the scheduled task (CronJob) deployment template, closing a gap with the k8s deployment template which already supported it. `tolerations` was already supported in both templates; only `nodeSelector` was missing from scheduled tasks.

## Changes
- `scheduled_task/deployment/templates/deployment.yaml.tpl`: render a `nodeSelector` block from `k8s_modifiers.deployment.nodeselector`, mirroring the existing `tolerations` block and sharing the same `{{- if $deployment }}` guard.
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Notes
- The modifier field key is lowercase `nodeselector` (the platform's modifier name), rendered to the k8s-canonical `nodeSelector:` key — same convention as the k8s deployment template.
- Uses `indent 10` (not `8`) because the CronJob nests the pod spec under `jobTemplate → spec → template → spec`, matching the sibling `tolerations` block.
- No `values.yaml` change needed — `k8s_modifiers` are injected by the platform at render time.

## Test plan
- [ ] Deploy a scheduled task scope with a `deployment.nodeselector` modifier and confirm the CronJob pod template renders `nodeSelector`.