### PR TITLE
Hotfix: revert PR #196 (scheduled task nodeSelector)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support to get AWS credentials via assume role
 - Add support to auto-create ALBs on scope create
 - Fix race condition on IAM role creation when multiple scopes are created concurrently
-- Add nodeSelector support for scheduled task scopes
 
 ## [1.12.0] - 2026-06-08
 - Fix: do not inject file parameter as env vars

--- a/scheduled_task/deployment/templates/deployment.yaml.tpl
+++ b/scheduled_task/deployment/templates/deployment.yaml.tpl
@@ -124,11 +124,6 @@ spec:
           tolerations:
 {{ data.ToYAML $tolerations | indent 10 }}
             {{- end }}
-            {{- $nodeSelector := index $deployment "nodeselector" }}
-            {{- if $nodeSelector }}
-          nodeSelector:
-{{ data.ToYAML $nodeSelector | indent 10 }}
-            {{- end }}
           {{- end }}
           {{- if .pull_secrets.ENABLED }}
           imagePullSecrets:


### PR DESCRIPTION
## Summary
Revierte el merge del PR #196 (`feat/scheduled-task-nodeselector`), que parece estar rompiendo los deployments de scheduled tasks en beta.

Cambios revertidos:
- `scheduled_task/deployment/templates/deployment.yaml.tpl`: bloque `nodeSelector` (5 líneas)
- `CHANGELOG.md`: entrada correspondiente

Una vez identificada la causa raíz, el cambio original puede re-aplicarse revirtiendo este revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)