### PR TITLE
feat: re-add scheduled task nodeSelector with correct indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support to get AWS credentials via assume role
 - Add support to auto-create ALBs on scope create
 - Fix race condition on IAM role creation when multiple scopes are created concurrently
+- Add nodeSelector support for scheduled task scopes
 
 ## [1.12.0] - 2026-06-08
 - Fix: do not inject file parameter as env vars

--- a/scheduled_task/deployment/templates/deployment.yaml.tpl
+++ b/scheduled_task/deployment/templates/deployment.yaml.tpl
@@ -124,6 +124,11 @@ spec:
           tolerations:
 {{ data.ToYAML $tolerations | indent 10 }}
             {{- end }}
+            {{- $nodeSelector := index $deployment "nodeselector" }}
+            {{- if $nodeSelector }}
+          nodeSelector:
+{{ data.ToYAML $nodeSelector | indent 12 }}
+            {{- end }}
           {{- end }}
           {{- if .pull_secrets.ENABLED }}
           imagePullSecrets:


### PR DESCRIPTION
## Summary
Re-adds `nodeSelector` support for scheduled task (CronJob) scopes. This **supersedes #196**, which was reverted (#197) because it rendered invalid YAML and broke deployments:

```
CronJob in version "v1" cannot be handled as a CronJob: strict decoding error:
unknown field "spec.jobTemplate.spec.template.spec.kubernetes.io/arch"
```

## Root cause of the original breakage
`nodeSelector` is a **map**, but its content was rendered at `indent 10` — the same column as the `nodeSelector:` key. That made the map entries (e.g. `kubernetes.io/arch: arm64`) *siblings* of `nodeSelector:` under `template.spec` instead of children. The neighboring `tolerations` block uses the same `indent 10` and works only because it is a **sequence** (`- ` markers disambiguate nesting).

## Fix
Render the `nodeSelector` map content at `indent 12`, two spaces deeper than its key (the k8s deployment template already follows this rule).

## Verification
Rendered the full CronJob template with the real arm64 modifier; `kubernetes.io/arch: arm64` now nests correctly under `nodeSelector:`.

## Changes
- `scheduled_task/deployment/templates/deployment.yaml.tpl`: `nodeSelector` block at `indent 12`.
- `CHANGELOG.md`: re-added the `[Unreleased]` entry removed by the revert.